### PR TITLE
cinnamon-system-settings@100savage: use symbolic icon for menu action

### DIFF
--- a/cinnamon-system-settings@100savage/cinnamon-system-settings@100savage.nemo_action.in
+++ b/cinnamon-system-settings@100savage/cinnamon-system-settings@100savage.nemo_action.in
@@ -1,7 +1,7 @@
 [Nemo Action]
 _Name=System Settings
 Exec=cinnamon-settings
-Icon-Name=applications-system
+Icon-Name=applications-system-symbolic
 Selection=None
 Extensions=any;
 Conditions=desktop;


### PR DESCRIPTION
Symbolic works best with the other options in the desktop context menu.

cc @100savage