### PR TITLE
Change desktop context menu icons to symbolic icons

### DIFF
--- a/gnome-system-monitor@100savage/gnome-system-monitor@100savage.nemo_action.in
+++ b/gnome-system-monitor@100savage/gnome-system-monitor@100savage.nemo_action.in
@@ -1,7 +1,7 @@
 [Nemo Action]
 _Name=GNOME System Monitor
 Exec=gnome-system-monitor
-Icon-Name=org.gnome.SystemMonitor
+Icon-Name=org.gnome.SystemMonitor-symbolic
 Selection=None
 Extensions=any;
 Conditions=desktop;

--- a/restart-cinnamon@claudiux/restart-cinnamon@claudiux.nemo_action.in
+++ b/restart-cinnamon@claudiux/restart-cinnamon@claudiux.nemo_action.in
@@ -1,7 +1,7 @@
 [Nemo Action]
 _Name=Restart Cinnamon
 Exec=cinnamon -r
-Icon-Name=reload
+Icon-Name=view-refresh-symbolic
 Selection=None
 Extensions=any;
 Conditions=desktop;


### PR DESCRIPTION
The change is to preserve the visual consistency of the icons.

![i-dark](https://github.com/linuxmint/cinnamon-spices-actions/assets/68134588/8d5f3a06-1e0c-4621-a09c-ee2414eeeaf1)
![i-white](https://github.com/linuxmint/cinnamon-spices-actions/assets/68134588/7c5b6342-9529-40ff-8478-700eca49fb84)
