### PR TITLE
reload-all-desklets@rcalixte: call zenity in the end instead of during loading time

### DIFF
--- a/reload-all-desklets@rcalixte/files/reload-all-desklets@rcalixte/reload-all-desklets@rcalixte.py
+++ b/reload-all-desklets@rcalixte/files/reload-all-desklets@rcalixte/reload-all-desklets@rcalixte.py
@@ -13,7 +13,7 @@ UUID: str = 'reload-all-desklets@rcalixte'
 HOME: str = os.path.expanduser('~')
 gettext.bindtextdomain(f'{HOME}/.local/share/locale')
 gettext.textdomain(UUID)
-TEXT: str = gettext.gettext("Reloading...")
+TEXT: str = gettext.gettext("All active desklets were reloaded.")
 BUS_TYPE: Gio.BusType = Gio.BusType.SESSION
 DBUS_PATH: str = 'org.Cinnamon'
 DESKLET: str = 'DESKLET'
@@ -39,20 +39,17 @@ def main():
     if not proxy:
         sys.exit(1)
 
-    with subprocess.Popen(['/usr/bin/zenity', '--progress', '--auto-close',
-                           '--pulsate', '--no-cancel', f'--text={TEXT}',
-                           '--title=']) as process:
-        for desklet in enabled_desklets:
-            if desklet not in BADS:
-                try:
-                    proxy.ReloadXlet('(ss)', desklet, DESKLET)
-                    time.sleep(0.05)
-                    proxy.ReloadXlet('(ss)', desklet, DESKLET)
-                    time.sleep(0.01)
-                except GLib.GError:
-                    time.sleep(0.05)
+    for desklet in enabled_desklets:
+        if desklet not in BADS:
+            try:
+                proxy.ReloadXlet('(ss)', desklet, DESKLET)
+                time.sleep(0.05)
+                proxy.ReloadXlet('(ss)', desklet, DESKLET)
+                time.sleep(0.01)
+            except GLib.GError:
+                time.sleep(0.05)
 
-        os.kill(process.pid, signal.SIGTERM)
+    subprocess.run(["/usr/bin/zenity", "--info", f"--text={TEXT}"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The loading of the desklets takes way less time than it generally takes to create a zenity window, so, the zenity process would end up being killed before even showing the window to the user interface. So instead of trying to create a zenity window during loading time, it's best to create an information window at the end to inform the user that the process has ended, shifting the focus of the user from the desktop (which is our primary goal).

cc @rcalixte 

solves https://github.com/linuxmint/mint21.3-beta/issues/26