### PR TITLE
restart-cinnamon@claudiux: Add DBus condition

### DIFF
--- a/restart-cinnamon@claudiux/restart-cinnamon@claudiux.nemo_action.in
+++ b/restart-cinnamon@claudiux/restart-cinnamon@claudiux.nemo_action.in
@@ -4,4 +4,4 @@ Exec=cinnamon -r
 Icon-Name=view-refresh-symbolic
 Selection=None
 Extensions=any;
-Conditions=desktop;
+Conditions=dbus org.Cinnamon;desktop;


### PR DESCRIPTION
This change will prevent the menu option from being shown on non-Cinnamon desktop environments where Nemo is still drawing the desktop (e.g. a user has Cinnamon and GNOME installed, using Nemo for both desktops, and switches between them).

cc @claudiux 