### PR TITLE
cinnamon-take-screenshot@duracell80: fallback to the xdg pictures dir if screenshot folder unset

### DIFF
--- a/cinnamon-take-screenshot@duracell80/files/cinnamon-take-screenshot@duracell80/cinnamon-take-screenshot.sh
+++ b/cinnamon-take-screenshot@duracell80/files/cinnamon-take-screenshot@duracell80/cinnamon-take-screenshot.sh
@@ -8,8 +8,14 @@ DIR_PWD=$(pwd)
 DIR_AUTOSAVE=$(gsettings get org.gnome.gnome-screenshot auto-save-directory)
 
 if [ "${DIR_AUTOSAVE}" = "''" ]; then
+	PICTURES_DIR="${HOME}/Pictures"
+
+	if command xdg-user-dir &> /dev/null ; then
+		PICTURES_DIR=$(xdg-user-dir PICTURES)
+	fi
+
 	# FALL BACK
-	DIR_TGT="${HOME}/Pictures/screenshots"
+	DIR_TGT="$PICTURES_DIR/Screenshots"
 else
 	# USERS CHOICE
 	DIR_TGT=$(echo "${DIR_AUTOSAVE}" | sed "s/'//g")

--- a/cinnamon-take-screenshot@duracell80/files/cinnamon-take-screenshot@duracell80/cinnamon-take-screenshot.sh
+++ b/cinnamon-take-screenshot@duracell80/files/cinnamon-take-screenshot@duracell80/cinnamon-take-screenshot.sh
@@ -10,7 +10,7 @@ DIR_AUTOSAVE=$(gsettings get org.gnome.gnome-screenshot auto-save-directory)
 if [ "${DIR_AUTOSAVE}" = "''" ]; then
 	PICTURES_DIR="${HOME}/Pictures"
 
-	if command xdg-user-dir &> /dev/null ; then
+	if command -v xdg-user-dir &> /dev/null ; then
 		PICTURES_DIR=$(xdg-user-dir PICTURES)
 	fi
 


### PR DESCRIPTION
This will make it fallback to the default image folder which may be different from **Pictures** if the default locale for the computer is set to a language different than English.

@duracell80 please tell me if you approve this update.

*(Btw, nice action, I liked it)*