### PR TITLE
create-desktop-shortcut@anaximeno: Exclude impossible places

### DIFF
--- a/create-desktop-shortcut@anaximeno/files/create-desktop-shortcut@anaximeno/check.sh
+++ b/create-desktop-shortcut@anaximeno/files/create-desktop-shortcut@anaximeno/check.sh
@@ -9,4 +9,10 @@ if [[ $ACTION_DIR -ef $DESKTOP ]]; then
     exit 1
 fi
 
+# Some locations like trash or recent don't return a parent dir.
+# It is not possible to create a shortcut of them.
+if [[ -z "$ACTION_DIR" ]]; then
+    exit 1
+fi
+
 exit 0


### PR DESCRIPTION
Some places in nemo like recent files, trash or the root file system do not return a valid `ACTION_DIR`. Hide the action on those since the action will fail.