### PR TITLE
send-as-attachment@rcalixte: added hr translation

### DIFF
--- a/send-as-attachment@rcalixte/files/send-as-attachment@rcalixte/po/hr.po
+++ b/send-as-attachment@rcalixte/files/send-as-attachment@rcalixte/po/hr.po
@@ -1,0 +1,33 @@
+# SOME DESCRIPTIVE TITLE.
+# This file is put in the public domain.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: send-as-attachment@rcalixte 1.1\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
+"issues\n"
+"POT-Creation-Date: 2024-02-17 16:11+0100\n"
+"PO-Revision-Date: 2024-02-17 16:28+0100\n"
+"Last-Translator: Mikeyy\n"
+"Language-Team: \n"
+"Language: hr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"X-Generator: Poedit 3.0.1\n"
+
+#. metadata.json->description
+msgid "Send file(s) as attachments via a local e-mail client"
+msgstr "Pošalji datoteke kao privitke putem lokalnog klijenta e-pošte"
+
+#. metadata.json->name
+#. send-as-attachment@rcalixte.nemo_action.in->Name
+msgid "Send as Attachment"
+msgstr "Pošalji kao privitak"
+
+#. send-as-attachment@rcalixte.nemo_action.in->Comment
+msgid "Attach to a new e-mail"
+msgstr "Prikači za novu poruku e-pošte"


### PR DESCRIPTION
Added hr (Croatian) translation for send-as-attachment @rcalixte