### PR TITLE
paste-into-file@anaximeno: Update clipboard access method

### DIFF
--- a/paste-into-file@anaximeno/README.md
+++ b/paste-into-file@anaximeno/README.md
@@ -4,4 +4,4 @@ Paste clipboard content into a file.
 
 ### Dependencies
 
-- Python3, xclip, Gtk3
+- Python3, Gtk3

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/check.py
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/check.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
 import os, sys
-import subprocess
 
 
 def main() -> None:
@@ -21,18 +20,6 @@ def main() -> None:
     # Check write perms if file given
     if len(files) == 1 and not os.access(files[0].replace("\\ ", " "), os.W_OK):
         exit(1)
-
-    ## XXX: It doesn't work very well if the user performed a cut operation before
-    ##    triggering the check below.
-    # command = ["xclip", "-out", "-selection", "clipboard"]
-
-    # clipcontent = subprocess.run(
-    #     command, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=0.5,
-    # ).stdout.decode("utf-8")
-
-    # # Check if the clipboard is not empty
-    # if clipcontent.strip() == "":
-    #     exit(1)
 
     exit(0)
 

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/metadata.json
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/metadata.json
@@ -3,5 +3,5 @@
     "uuid": "paste-into-file@anaximeno",
     "name": "Paste into file",
     "author": "anaximeno",
-    "version": "1.2.0"
+    "version": "1.1.0"
 }

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/metadata.json
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/metadata.json
@@ -3,5 +3,5 @@
     "uuid": "paste-into-file@anaximeno",
     "name": "Paste into file",
     "author": "anaximeno",
-    "version": "1.0.1"
+    "version": "1.2.0"
 }

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/es.po
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: paste-into-file@anaximeno 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2024-03-04 08:16-0100\n"
+"POT-Creation-Date: 2024-03-04 17:19-0100\n"
 "PO-Revision-Date: 2024-03-03 20:15-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -41,22 +41,22 @@ msgstr ""
 msgid "Invalid file name!"
 msgstr "Nombre de archivo no válido!"
 
-#: text.py:24
-msgid ""
-"There's nothing on the clipboard to paste into a file! Aborting operation..."
+#: text.py:23
+msgid "No content found in clipboard. Operation cancelled."
 msgstr ""
 
-#: text.py:27
-msgid "Append to the end of the file"
+#: text.py:26
+#, fuzzy
+msgid "Paste to the end of the file."
+msgstr "Pegar el contenido del portapapeles en un archivo."
+
+#: text.py:28
+msgid "Replace the content of the file."
 msgstr ""
 
-#: text.py:29
-msgid "Override the content of the file"
-msgstr ""
-
-#: text.py:31
+#: text.py:30
 #, python-format
-msgid "File '%s' already exists. How to proceed?"
+msgid "File '%s' already exists."
 msgstr ""
 
 #. metadata.json->description

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/es.po
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: paste-into-file@anaximeno 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2024-03-04 08:04-0100\n"
+"POT-Creation-Date: 2024-03-04 08:11-0100\n"
 "PO-Revision-Date: 2024-03-03 20:15-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -43,7 +43,7 @@ msgstr "Nombre de archivo no válido!"
 
 #: text.py:24
 msgid ""
-"There's nothing on the clipboard to paste into file! Aborting operation..."
+"There's nothing on the clipboard to paste into a file! Aborting operation..."
 msgstr ""
 
 #. metadata.json->description

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/es.po
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: paste-into-file@anaximeno 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2024-03-03 21:34-0100\n"
+"POT-Creation-Date: 2024-03-04 08:04-0100\n"
 "PO-Revision-Date: 2024-03-03 20:15-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -42,10 +42,9 @@ msgid "Invalid file name!"
 msgstr "Nombre de archivo no válido!"
 
 #: text.py:24
-msgid "Operation canceled, taking too long to obtain the clipboard content!"
+msgid ""
+"There's nothing on the clipboard to paste into file! Aborting operation..."
 msgstr ""
-"Operación cancelada, ¡se ha tardado demasiado en obtener el contenido del "
-"portapapeles!"
 
 #. metadata.json->description
 #. paste-into-file@anaximeno.nemo_action.in->Comment

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/es.po
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/es.po
@@ -9,7 +9,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
 "POT-Creation-Date: 2024-03-04 17:19-0100\n"
-"PO-Revision-Date: 2024-03-03 20:15-0300\n"
+"PO-Revision-Date: 2024-03-04 17:25-0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -46,9 +46,8 @@ msgid "No content found in clipboard. Operation cancelled."
 msgstr ""
 
 #: text.py:26
-#, fuzzy
 msgid "Paste to the end of the file."
-msgstr "Pegar el contenido del portapapeles en un archivo."
+msgstr ""
 
 #: text.py:28
 msgid "Replace the content of the file."

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/es.po
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: paste-into-file@anaximeno 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2024-03-04 08:11-0100\n"
+"POT-Creation-Date: 2024-03-04 08:16-0100\n"
 "PO-Revision-Date: 2024-03-03 20:15-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -44,6 +44,19 @@ msgstr "Nombre de archivo no válido!"
 #: text.py:24
 msgid ""
 "There's nothing on the clipboard to paste into a file! Aborting operation..."
+msgstr ""
+
+#: text.py:27
+msgid "Append to the end of the file"
+msgstr ""
+
+#: text.py:29
+msgid "Override the content of the file"
+msgstr ""
+
+#: text.py:31
+#, python-format
+msgid "File '%s' already exists. How to proceed?"
 msgstr ""
 
 #. metadata.json->description

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/hu.po
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/hu.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: paste-into-file@anaximeno 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2024-03-03 21:34-0100\n"
+"POT-Creation-Date: 2024-03-04 08:04-0100\n"
 "PO-Revision-Date: 2024-03-03 19:38+0100\n"
 "Last-Translator: Vajda Örs <ors0092@gmail.com>\n"
 "Language-Team: \n"
@@ -42,7 +42,8 @@ msgid "Invalid file name!"
 msgstr "Érvénytelen fáljnév!"
 
 #: text.py:24
-msgid "Operation canceled, taking too long to obtain the clipboard content!"
+msgid ""
+"There's nothing on the clipboard to paste into file! Aborting operation..."
 msgstr ""
 
 #. metadata.json->description

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/hu.po
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/hu.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: paste-into-file@anaximeno 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2024-03-04 08:04-0100\n"
+"POT-Creation-Date: 2024-03-04 08:11-0100\n"
 "PO-Revision-Date: 2024-03-03 19:38+0100\n"
 "Last-Translator: Vajda Örs <ors0092@gmail.com>\n"
 "Language-Team: \n"
@@ -43,7 +43,7 @@ msgstr "Érvénytelen fáljnév!"
 
 #: text.py:24
 msgid ""
-"There's nothing on the clipboard to paste into file! Aborting operation..."
+"There's nothing on the clipboard to paste into a file! Aborting operation..."
 msgstr ""
 
 #. metadata.json->description

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/hu.po
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
 "POT-Creation-Date: 2024-03-04 17:19-0100\n"
-"PO-Revision-Date: 2024-03-03 19:38+0100\n"
+"PO-Revision-Date: 2024-03-04 17:25-0100\n"
 "Last-Translator: Vajda Örs <ors0092@gmail.com>\n"
 "Language-Team: \n"
 "Language: hu\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.0.1\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #. metadata.json->name
 #. paste-into-file@anaximeno.nemo_action.in->Name
@@ -46,9 +46,8 @@ msgid "No content found in clipboard. Operation cancelled."
 msgstr ""
 
 #: text.py:26
-#, fuzzy
 msgid "Paste to the end of the file."
-msgstr "Illessze be a vágólap tartalmát egy fájlba."
+msgstr ""
 
 #: text.py:28
 msgid "Replace the content of the file."

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/hu.po
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/hu.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: paste-into-file@anaximeno 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2024-03-04 08:11-0100\n"
+"POT-Creation-Date: 2024-03-04 08:16-0100\n"
 "PO-Revision-Date: 2024-03-03 19:38+0100\n"
 "Last-Translator: Vajda Örs <ors0092@gmail.com>\n"
 "Language-Team: \n"
@@ -44,6 +44,19 @@ msgstr "Érvénytelen fáljnév!"
 #: text.py:24
 msgid ""
 "There's nothing on the clipboard to paste into a file! Aborting operation..."
+msgstr ""
+
+#: text.py:27
+msgid "Append to the end of the file"
+msgstr ""
+
+#: text.py:29
+msgid "Override the content of the file"
+msgstr ""
+
+#: text.py:31
+#, python-format
+msgid "File '%s' already exists. How to proceed?"
 msgstr ""
 
 #. metadata.json->description

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/hu.po
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/hu.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: paste-into-file@anaximeno 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2024-03-04 08:16-0100\n"
+"POT-Creation-Date: 2024-03-04 17:19-0100\n"
 "PO-Revision-Date: 2024-03-03 19:38+0100\n"
 "Last-Translator: Vajda Örs <ors0092@gmail.com>\n"
 "Language-Team: \n"
@@ -41,22 +41,22 @@ msgstr ""
 msgid "Invalid file name!"
 msgstr "Érvénytelen fáljnév!"
 
-#: text.py:24
-msgid ""
-"There's nothing on the clipboard to paste into a file! Aborting operation..."
+#: text.py:23
+msgid "No content found in clipboard. Operation cancelled."
 msgstr ""
 
-#: text.py:27
-msgid "Append to the end of the file"
+#: text.py:26
+#, fuzzy
+msgid "Paste to the end of the file."
+msgstr "Illessze be a vágólap tartalmát egy fájlba."
+
+#: text.py:28
+msgid "Replace the content of the file."
 msgstr ""
 
-#: text.py:29
-msgid "Override the content of the file"
-msgstr ""
-
-#: text.py:31
+#: text.py:30
 #, python-format
-msgid "File '%s' already exists. How to proceed?"
+msgid "File '%s' already exists."
 msgstr ""
 
 #. metadata.json->description

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/paste-into-file@anaximeno.pot
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/paste-into-file@anaximeno.pot
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: paste-into-file@anaximeno 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2024-03-04 08:11-0100\n"
+"POT-Creation-Date: 2024-03-04 08:16-0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -41,6 +41,19 @@ msgstr ""
 #: text.py:24
 msgid ""
 "There's nothing on the clipboard to paste into a file! Aborting operation..."
+msgstr ""
+
+#: text.py:27
+msgid "Append to the end of the file"
+msgstr ""
+
+#: text.py:29
+msgid "Override the content of the file"
+msgstr ""
+
+#: text.py:31
+#, python-format
+msgid "File '%s' already exists. How to proceed?"
 msgstr ""
 
 #. metadata.json->description

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/paste-into-file@anaximeno.pot
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/paste-into-file@anaximeno.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: paste-into-file@anaximeno 1.0.1\n"
+"Project-Id-Version: paste-into-file@anaximeno 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2024-03-04 08:04-0100\n"
+"POT-Creation-Date: 2024-03-04 08:11-0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -40,7 +40,7 @@ msgstr ""
 
 #: text.py:24
 msgid ""
-"There's nothing on the clipboard to paste into file! Aborting operation..."
+"There's nothing on the clipboard to paste into a file! Aborting operation..."
 msgstr ""
 
 #. metadata.json->description

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/paste-into-file@anaximeno.pot
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/paste-into-file@anaximeno.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: paste-into-file@anaximeno 1.2.0\n"
+"Project-Id-Version: paste-into-file@anaximeno 1.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2024-03-04 08:16-0100\n"
+"POT-Creation-Date: 2024-03-04 17:19-0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,22 +38,21 @@ msgstr ""
 msgid "Invalid file name!"
 msgstr ""
 
-#: text.py:24
-msgid ""
-"There's nothing on the clipboard to paste into a file! Aborting operation..."
+#: text.py:23
+msgid "No content found in clipboard. Operation cancelled."
 msgstr ""
 
-#: text.py:27
-msgid "Append to the end of the file"
+#: text.py:26
+msgid "Paste to the end of the file."
 msgstr ""
 
-#: text.py:29
-msgid "Override the content of the file"
+#: text.py:28
+msgid "Replace the content of the file."
 msgstr ""
 
-#: text.py:31
+#: text.py:30
 #, python-format
-msgid "File '%s' already exists. How to proceed?"
+msgid "File '%s' already exists."
 msgstr ""
 
 #. metadata.json->description

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/paste-into-file@anaximeno.pot
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/paste-into-file@anaximeno.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: paste-into-file@anaximeno 1.0.0\n"
+"Project-Id-Version: paste-into-file@anaximeno 1.0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2024-03-03 21:34-0100\n"
+"POT-Creation-Date: 2024-03-04 08:04-0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -39,7 +39,8 @@ msgid "Invalid file name!"
 msgstr ""
 
 #: text.py:24
-msgid "Operation canceled, taking too long to obtain the clipboard content!"
+msgid ""
+"There's nothing on the clipboard to paste into file! Aborting operation..."
 msgstr ""
 
 #. metadata.json->description

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/pt.po
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/pt.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: paste-into-file@anaximeno 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2024-03-03 21:34-0100\n"
+"POT-Creation-Date: 2024-03-04 08:04-0100\n"
 "PO-Revision-Date: 2024-03-03 21:38-0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -42,10 +42,9 @@ msgid "Invalid file name!"
 msgstr "Nome de ficheiro invalido!"
 
 #: text.py:24
-msgid "Operation canceled, taking too long to obtain the clipboard content!"
+msgid ""
+"There's nothing on the clipboard to paste into file! Aborting operation..."
 msgstr ""
-"Operação cancelada, demorando muito para obter o conteúdo da área de "
-"transferência!"
 
 #. metadata.json->description
 #. paste-into-file@anaximeno.nemo_action.in->Comment

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/pt.po
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/pt.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: paste-into-file@anaximeno 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2024-03-04 08:16-0100\n"
-"PO-Revision-Date: 2024-03-04 08:12-0100\n"
+"POT-Creation-Date: 2024-03-04 17:19-0100\n"
+"PO-Revision-Date: 2024-03-04 17:23-0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: pt\n"
@@ -41,25 +41,23 @@ msgstr ""
 msgid "Invalid file name!"
 msgstr "Nome de ficheiro invalido!"
 
-#: text.py:24
-msgid ""
-"There's nothing on the clipboard to paste into a file! Aborting operation..."
+#: text.py:23
+msgid "No content found in clipboard. Operation cancelled."
 msgstr ""
-"Não há nada na área de transferência para colar num ficheiro! Abortando a "
-"operação..."
+"Nenhum conteúdo encontrado na área de transferência. Operação cancelada."
 
-#: text.py:27
-msgid "Append to the end of the file"
-msgstr ""
+#: text.py:26
+msgid "Paste to the end of the file."
+msgstr "Colar para o final do ficheiro."
 
-#: text.py:29
-msgid "Override the content of the file"
-msgstr ""
+#: text.py:28
+msgid "Replace the content of the file."
+msgstr "Trocar o conteúdo do ficheiro."
 
-#: text.py:31
+#: text.py:30
 #, python-format
-msgid "File '%s' already exists. How to proceed?"
-msgstr ""
+msgid "File '%s' already exists."
+msgstr "Ficheiro '%s' já existe."
 
 #. metadata.json->description
 #. paste-into-file@anaximeno.nemo_action.in->Comment

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/pt.po
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/pt.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: paste-into-file@anaximeno 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2024-03-04 08:11-0100\n"
+"POT-Creation-Date: 2024-03-04 08:16-0100\n"
 "PO-Revision-Date: 2024-03-04 08:12-0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -47,6 +47,19 @@ msgid ""
 msgstr ""
 "Não há nada na área de transferência para colar num ficheiro! Abortando a "
 "operação..."
+
+#: text.py:27
+msgid "Append to the end of the file"
+msgstr ""
+
+#: text.py:29
+msgid "Override the content of the file"
+msgstr ""
+
+#: text.py:31
+#, python-format
+msgid "File '%s' already exists. How to proceed?"
+msgstr ""
 
 #. metadata.json->description
 #. paste-into-file@anaximeno.nemo_action.in->Comment

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/pt.po
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/pt.po
@@ -9,7 +9,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
 "POT-Creation-Date: 2024-03-04 08:04-0100\n"
-"PO-Revision-Date: 2024-03-03 21:38-0100\n"
+"PO-Revision-Date: 2024-03-04 08:06-0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: pt\n"
@@ -45,6 +45,8 @@ msgstr "Nome de ficheiro invalido!"
 msgid ""
 "There's nothing on the clipboard to paste into file! Aborting operation..."
 msgstr ""
+"Não há nada na área de transferência para colar no ficheiro! Abortando a "
+"operação..."
 
 #. metadata.json->description
 #. paste-into-file@anaximeno.nemo_action.in->Comment

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/pt.po
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/po/pt.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: paste-into-file@anaximeno 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2024-03-04 08:04-0100\n"
-"PO-Revision-Date: 2024-03-04 08:06-0100\n"
+"POT-Creation-Date: 2024-03-04 08:11-0100\n"
+"PO-Revision-Date: 2024-03-04 08:12-0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: pt\n"
@@ -43,9 +43,9 @@ msgstr "Nome de ficheiro invalido!"
 
 #: text.py:24
 msgid ""
-"There's nothing on the clipboard to paste into file! Aborting operation..."
+"There's nothing on the clipboard to paste into a file! Aborting operation..."
 msgstr ""
-"Não há nada na área de transferência para colar no ficheiro! Abortando a "
+"Não há nada na área de transferência para colar num ficheiro! Abortando a "
 "operação..."
 
 #. metadata.json->description

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/text.py
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/text.py
@@ -23,3 +23,9 @@ INVALID_FILE_NAME = _("Invalid file name!")
 NO_CLIPBOARD_CONTENT = _(
     "There's nothing on the clipboard to paste into a file! Aborting operation..."
 )
+# NOTE: these below aren't used yet, but might need them in a future release
+APPEND_TO_END = _("Append to the end of the file")
+
+OVERRIDE_CONTENT = _("Override the content of the file")
+
+FILE_EXISTS = _("File '%s' already exists. How to proceed?")

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/text.py
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/text.py
@@ -21,5 +21,5 @@ FILE_EXISTS = _(
 INVALID_FILE_NAME = _("Invalid file name!")
 
 NO_CLIPBOARD_CONTENT = _(
-    "There's nothing on the clipboard to paste into file! Aborting operation..."
+    "There's nothing on the clipboard to paste into a file! Aborting operation..."
 )

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/text.py
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/text.py
@@ -20,12 +20,11 @@ FILE_EXISTS = _(
 
 INVALID_FILE_NAME = _("Invalid file name!")
 
-NO_CLIPBOARD_CONTENT = _(
-    "There's nothing on the clipboard to paste into a file! Aborting operation..."
-)
+NO_CLIPBOARD_CONTENT = _("No content found in clipboard. Operation cancelled.")
+
 # NOTE: these below aren't used yet, but might need them in a future release
-APPEND_TO_END = _("Append to the end of the file")
+APPEND_TO_END = _("Paste to the end of the file.")
 
-OVERRIDE_CONTENT = _("Override the content of the file")
+OVERRIDE_CONTENT = _("Replace the content of the file.")
 
-FILE_EXISTS = _("File '%s' already exists. How to proceed?")
+STATE_THAT_FILE_EXISTS = _("File '%s' already exists.")

--- a/paste-into-file@anaximeno/files/paste-into-file@anaximeno/text.py
+++ b/paste-into-file@anaximeno/files/paste-into-file@anaximeno/text.py
@@ -20,6 +20,6 @@ FILE_EXISTS = _(
 
 INVALID_FILE_NAME = _("Invalid file name!")
 
-TIMEOUT_EXPIRED_MSG = _(
-    "Operation canceled, taking too long to obtain the clipboard content!"
+NO_CLIPBOARD_CONTENT = _(
+    "There's nothing on the clipboard to paste into file! Aborting operation..."
 )

--- a/paste-into-file@anaximeno/paste-into-file@anaximeno.nemo_action.in
+++ b/paste-into-file@anaximeno/paste-into-file@anaximeno.nemo_action.in
@@ -2,7 +2,7 @@
 _Name=Paste into file
 _Comment=Paste clipboard content into a file.
 Icon-Name=edit-paste-symbolic
-Dependencies=xclip;python3;
+Dependencies=python3;
 Exec=<paste-into-file@anaximeno/action.py "%P" "%F">
 Conditions=exec <paste-into-file@anaximeno/check.py "%P" "%F">;
 Mimetypes=text/plain;


### PR DESCRIPTION
Use `Gtk.Clipboard` instead of `xclip`, this way we avoid having xclip as a dependency.