### PR TITLE
Add confirmation dialog

### DIFF
--- a/file-shredder@czmisacz/files/file-shredder@czmisacz/action.sh
+++ b/file-shredder@czmisacz/files/file-shredder@czmisacz/action.sh
@@ -101,6 +101,15 @@ process_files_and_directories() {
 
 
 # Process multiple files or folders
+title="REALLY SHRED FILES?"
+text="This will permanently and irrevocably delete the following files and/or directories\!\r\n\\t\t\t\t\tIt will be impossible to undelete them\!\r\n\t\tYou must type \"SHRED FILES\" and then press OK here to shred them.\r\n\r\n$@"
+
+response=$(zenity --entry --title="$title" --text="$text")
+
+if [ "$response" != "SHRED FILES" ]; then
+    exit 0
+fi
+
 for file_to_corrupt in "$@"; do
     # Remove backslashes and quotes from the file path
     file_to_corrupt=$(echo "$file_to_corrupt" | sed 's/\\//g' | tr -d '"')


### PR DESCRIPTION
I'd like to add a confirmation dialog to this action. On my system, "Shred files" appears directly above "Cut" in the context menu. One misclick, and a whole directory is irrevocably deleted.

This provides a possible solution to that. Zenity should be available on most distributions, so the dependency shouldn't be a problem.

This being my first PR to Cinnamon, I'm not sure how to add i8n support though.