### PR TITLE
check-with-virustotal: Added .po file for Brazilian Portuguese

### DIFF
--- a/check-with-virustotal@stilktf/files/check-with-virustotal@stilktf/po/pt_BR.po
+++ b/check-with-virustotal@stilktf/files/check-with-virustotal@stilktf/po/pt_BR.po
@@ -1,0 +1,36 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-13 17:17+0100\n"
+"PO-Revision-Date: 2024-04-25 23:57-0600\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. metadata.json->description
+msgid "Check a file's hash on VirusTotal"
+msgstr "Verificar o hash de um arquivo no VirusTotal"
+
+#. metadata.json->name
+#. Name
+msgid "Check with VirusTotal"
+msgstr "Verificar com VirusTotal"
+
+#. Comment
+msgid "Checks file hash with VirusTotal"
+msgstr "Verifica o hash do arquivo com o VirusTotal"
+
+#: check-with-virustotal@stilktf.sh:5
+msgid "Couldn't find file on VirusTotal."
+msgstr "Não foi possível encontrar o arquivo no VirusTotal."


### PR DESCRIPTION
Hi @stilktf

added the .po file to cover the Brazilian Portuguese translation
