### PR TITLE
Add Delay to Take Screenshot

### DIFF
--- a/cinnamon-take-screenshot@duracell80/README.md
+++ b/cinnamon-take-screenshot@duracell80/README.md
@@ -8,6 +8,8 @@ DESCRIPTION
 
 This action calls a screenshot utility directly from the desktop context menu to allow for the caputure of a selected area. It will auto save the capture to either the location noted from "gsettings get org.gnome.gnome-screenshot auto-save-directory" or a fallback in ~/Pictures/screenshots and display the file in pix.
 
+Now uses delay. To set type in a terminal "gsettings set org.gnome.gnome-screenshot delay 5" for a 5 second delay.
+
 DEPENDENCIES
 ------------
 

--- a/cinnamon-take-screenshot@duracell80/files/cinnamon-take-screenshot@duracell80/cinnamon-take-screenshot.sh
+++ b/cinnamon-take-screenshot@duracell80/files/cinnamon-take-screenshot@duracell80/cinnamon-take-screenshot.sh
@@ -57,8 +57,18 @@ else
     TS=$(date +%s)
 
     FILENAME="${DIR_TGT}/screenshot-auto_${TS}.png"
+    DELAY=$(gsettings get org.gnome.gnome-screenshot delay)
 
-    gnome-screenshot --area --file="$FILENAME"
+    # https://gitlab.gnome.org/GNOME/gnome-screenshot/-/issues/244
+    #POINT=$(gsettings get org.gnome.gnome-screenshot include-pointer)
+
+    if [[ $DELAY -gt 0 ]]; then
+		gnome-screenshot --delay=$DELAY --area --file="$FILENAME"
+		# GIVE FILESYSTEM CHANCE TO SAVE THE FILE
+		sleep 1
+    else
+		gnome-screenshot --area --file="$FILENAME"
+    fi
 
     if [[ ! -f "$FILENAME" ]]; then
 		notify-send -i camera-photo-symbolic -u low "$SCREENSHOT_NOT_TAKEN"


### PR DESCRIPTION
Get delay value from gsettings to allow action to also follow the desired delay by the user.