### PR TITLE
pdf-ocr@schorschii: Add support for non-English characters

### DIFF
--- a/pdf-ocr@schorschii/files/pdf-ocr@schorschii/metadata.json
+++ b/pdf-ocr@schorschii/files/pdf-ocr@schorschii/metadata.json
@@ -3,5 +3,5 @@
     "uuid": "pdf-ocr@schorschii",
     "name": "PDF OCR",
     "author": "schorschii",
-    "version": "1.0"
+    "version": "1.1"
 }

--- a/pdf-ocr@schorschii/files/pdf-ocr@schorschii/ocr-pdf.sh
+++ b/pdf-ocr@schorschii/files/pdf-ocr@schorschii/ocr-pdf.sh
@@ -15,7 +15,9 @@
     PERCENTAGE=$[$COUNTER * 100 / $#]
     echo "# $file" # update progress dialog text
     echo $PERCENTAGE # update progress dialog percentage
-    RUN=$(ocrmypdf -l "$LANGUAGES" "$file" "$file.ocr.pdf" 2>&1)
+    # `${file%.*}` removes the last file extension, e.g. `.pdf`,
+    # meaning if a file is called `foo.ocr.pdf`, it will only remove the `.pdf` part.
+    RUN=$(ocrmypdf -l "$LANGUAGES" "$file" "${file%.*}.ocr.pdf" 2>&1)
     OUTPUT="$OUTPUT$RUN"$'\n\n'
     COUNTER=$[$COUNTER + 1]
   done

--- a/pdf-ocr@schorschii/files/pdf-ocr@schorschii/ocr-pdf.sh
+++ b/pdf-ocr@schorschii/files/pdf-ocr@schorschii/ocr-pdf.sh
@@ -3,11 +3,19 @@
 (
   OUTPUT=""
   COUNTER=0
+  # Create an array containing all languages supported by tesseract.
+  # What we do:
+  #   remove the first line: `List of available languages in "/usr/share/tesseract-ocr/5/tessdata/" (5):`
+  #   remove "osd" (Orientation and Script Detection for languages not on this list) from the output
+  #   remove trailing newline characters using the `-t` option of readarray
+  readarray -t LANGUAGES < <(tesseract --list-langs | sed '1d' | sed '/osd/d')
+  # Create a string such as `deu+eng` by replacing whitespaces with `+`.
+  LANGUAGES=$(echo ${LANGUAGES[@]} | sed 's/\s/\+/g')
   for file in "$@"; do
     PERCENTAGE=$[$COUNTER * 100 / $#]
     echo "# $file" # update progress dialog text
     echo $PERCENTAGE # update progress dialog percentage
-    RUN=$(ocrmypdf "$file" "$file.ocr.pdf" 2>&1)
+    RUN=$(ocrmypdf -l "$LANGUAGES" "$file" "$file.ocr.pdf" 2>&1)
     OUTPUT="$OUTPUT$RUN"$'\n\n'
     COUNTER=$[$COUNTER + 1]
   done


### PR DESCRIPTION
See commit messages and comments for more information.

This makes the assumption that there isn't just support for *every* language installed. At least on Debian, only the English language support for tesseract gets installed by default. Meaning that any additional language support is installed manually.
I would argue that this assumption is better than assuming that every document being scanned only uses English characters.