### PR TITLE
Update compress-images.py

### DIFF
--- a/image-compressor@schorschii/files/image-compressor@schorschii/compress-images.py
+++ b/image-compressor@schorschii/files/image-compressor@schorschii/compress-images.py
@@ -53,7 +53,7 @@ class ImageWorker(Thread):
                 print("  Old width is smaller than target width, adjusting: newWidth = oldWidth")
                 newWidth = oldWidth
             newHeight = int(oldHeight * newWidth / oldWidth)
-            img = img.resize((newWidth,newHeight), Image.ANTIALIAS)
+            img = img.resize((newWidth,newHeight), Image.Resampling.LANCZOS)
             img.save(newFileName, optimize=True, quality=TARGET_QUALITY)
             print("Saved: " + newFileName)
 


### PR DESCRIPTION
There is a bug in `img = img.resize((newWidth,newHeight), Image.ANTIALIAS)`. 

ANTIALIAS was removed in Pillow 10.0.0 (after being deprecated through many previous versions). Now you need to use PIL.Image.LANCZOS or PIL.Image.Resampling.LANCZOS.

[Pillow documentation](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants)