### PR TITLE
link-target-to-tab@mdpenguin: handle links with parentheses in file name

### DIFF
--- a/link-target-to-tab@mdpenguin/files/link-target-to-tab@mdpenguin/link-target-to-tab.sh
+++ b/link-target-to-tab@mdpenguin/files/link-target-to-tab@mdpenguin/link-target-to-tab.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# remove backslashes passed in by Nemo so parentheses handled correctly and find link target path
+target_path=$(readlink -f "${1//'\'/}")
+
+# open link target path in new tab of active Nemo window
+nemo "$target_path" -t --existing-window

--- a/link-target-to-tab@mdpenguin/link-target-to-tab@mdpenguin.nemo_action.in
+++ b/link-target-to-tab@mdpenguin/link-target-to-tab@mdpenguin.nemo_action.in
@@ -15,4 +15,4 @@ Selection=s
 Extensions=any;
 
 # open link target in new tab
-Exec=sh -c 'target_path=$(readlink -f %F); nemo "$target_path" -t --existing-window'
+Exec=<link-target-to-tab@mdpenguin/link-target-to-tab.sh "%F">


### PR DESCRIPTION
Move exec command to separate script and modify to remove backslashes from file path passed in by Nemo to escape spaces in to fix issue where file paths with parentheses in them do not open correctly.