### PR TITLE
[copy-name-to-clipboard@torchipeppo] Fix multiple spaces

### DIFF
--- a/copy-name-to-clipboard@torchipeppo/CHANGELOG.md
+++ b/copy-name-to-clipboard@torchipeppo/CHANGELOG.md
@@ -2,3 +2,7 @@
 ### 1.0.0
 
 * Initial release
+
+### 1.0.1
+
+* Fix: multiple spaces are now properly copied instead of being collapsed into one

--- a/copy-name-to-clipboard@torchipeppo/copy-name-to-clipboard@torchipeppo.nemo_action.in
+++ b/copy-name-to-clipboard@torchipeppo/copy-name-to-clipboard@torchipeppo.nemo_action.in
@@ -1,7 +1,7 @@
 [Nemo Action]
 _Name=Copy name to clipboard
 _Comment=Copy the name of the selected item to the clipboard
-Exec=sh -c "echo -n $(basename %F) | xclip -selection clipboard"
+Exec=sh -c "echo -n \"$(basename %F)\" | xclip -selection clipboard"
 Selection=s
 Extensions=any;
 Icon-Name=edit-copy


### PR DESCRIPTION
Randomly encountered an annoying bug that caused multiple spaces to be collapsed into one, due to echo's functionality.
Shouldn't happen anymore.