### PR TITLE
Replacing basename with nemo specific filename variable %N

### DIFF
--- a/copy-name-to-clipboard@torchipeppo/copy-name-to-clipboard@torchipeppo.nemo_action.in
+++ b/copy-name-to-clipboard@torchipeppo/copy-name-to-clipboard@torchipeppo.nemo_action.in
@@ -1,7 +1,7 @@
 [Nemo Action]
 _Name=Copy name to clipboard
 _Comment=Copy the name of the selected item to the clipboard
-Exec=sh -c 'echo -n "%N" | xclip -selection clipboard'
+Exec=sh -c 'echo -n "%f" | xclip -selection clipboard'
 Selection=s
 Extensions=any;
 Icon-Name=edit-copy

--- a/copy-name-to-clipboard@torchipeppo/copy-name-to-clipboard@torchipeppo.nemo_action.in
+++ b/copy-name-to-clipboard@torchipeppo/copy-name-to-clipboard@torchipeppo.nemo_action.in
@@ -1,7 +1,7 @@
 [Nemo Action]
 _Name=Copy name to clipboard
 _Comment=Copy the name of the selected item to the clipboard
-Exec=sh -c "echo -n \"$(basename %F)\" | xclip -selection clipboard"
+Exec=sh -c 'echo -n "%N" | xclip -selection clipboard'
 Selection=s
 Extensions=any;
 Icon-Name=edit-copy


### PR DESCRIPTION
This change replaces the shell-based filename extraction using basename %F with Nemo's native %N filename variable. This simplifies the command, avoids shell quoting issues, and improves reliability.