### PR TITLE
vscodium@trymeouteh: match behavior of vscode-launcher

### DIFF
--- a/vscodium@trymeouteh/files/vscodium@trymeouteh/examine.sh
+++ b/vscodium@trymeouteh/files/vscodium@trymeouteh/examine.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+## Here we handle exception.
+## We will catch if currently right clicked directory actually exists,
+## ... Or is it the root filesystem?
+WORKING_DIR=$1
+
+
+## IF:   WORKING_DIR is empty      (eg. recents, trash or search results)   --- does not exist
+## OR:   WORKING_DIR is /          (eg. favorites or root filesystem)       --- we don't touch root filesystem
+if [[ -z "$WORKING_DIR" || "$WORKING_DIR" == '/' ]]; then
+    
+    # THEN: We exit with err. code 1, so that Nemo action will receive err. condition
+    # ...and won't continue executing, aka. won't show VSCode menu entry at all.
+    exit 1
+fi
+
+exit 0

--- a/vscodium@trymeouteh/vscodium@trymeouteh.nemo_action.in
+++ b/vscodium@trymeouteh/vscodium@trymeouteh.nemo_action.in
@@ -3,5 +3,6 @@ _Name=Open in VSCodium
 _Comment=Open VSCodium in the selected folder
 Exec=codium %P
 Icon-Name=vscodium
-Selection=Any
+Conditions=exec <vscodium@trymeouteh/examine.sh "%P">;
+Selection=None
 Extensions=dir;


### PR DESCRIPTION
Original author: @trymeouteh

`vscode-launcher` only appears in the context menu of the parent/current directory while `vscodium` also appears on directories contained inside it. When run on a contained directory, it counter-intuitively opens the current directory instead.\
`vscode-launcher` also doesn't appear for the root folder or folders with no name (like Trash).

`vscodium` has `Extensions=dir;` instead of `vscode-launcher`'s `Extensions=any;`, but because of the above changes I don't think it will matter.