### PR TITLE
convert-image-format@el-amine-404: update to v0.2.0

### DIFF
--- a/convert-image-format@el-amine-404/CHANGELOG.md
+++ b/convert-image-format@el-amine-404/CHANGELOG.md
@@ -10,3 +10,20 @@
     * Added a feature that allows converting PDFs into image formats such as PNG, JPG, and TIFF.
     * Users can specify additional parameters like resolution (DPI), the range of pages to convert, and the image format.
     * Default values will be applied if the user leaves fields empty.
+
+### 0.2.0
+
+* New Features:
+
+1. Merge to PDF: Added the ability to combine multiple selected images into a single PDF document.
+2. Animated GIF Creation: Added the ability to merge multiple images into a single animated GIF.
+3. JPEG XL Support: Added support for converting images to and from the JPEG XL (.jxl) format.
+4. Better SVG Tracing: Added VTracer to convert raster images into vector graphics
+5. Overwrite Protection: The script now checks if a filename exists and automatically renames the output (e.g., file_1.png) to prevent accidental data loss.
+6. Error Reporting: Added a detailed error log window that displays specific failure messages if a conversion is unsuccessful.
+
+* Improvements:
+
+1. Dependency Checking: The script now verifies that all required tools (e.g., zenity, img2pdf) are installed before running.
+2. Code Refactoring: Major cleanup of the codebase, moving logic into modular functions and improving localization handling.
+3. Skipped File Summary: Users are now notified with a list of specific files that were skipped due to unsupported formats.

--- a/convert-image-format@el-amine-404/README.md
+++ b/convert-image-format@el-amine-404/README.md
@@ -6,8 +6,8 @@ Easily convert image files to various formats or turn PDF files into images dire
 
 This action allows you to:
 - Convert single or multiple image files to a variety of formats (currently 15 formats and their variants).
-- Convert PDF files into images where each page is converted into an image. The action will generate a folder named after the PDF file in the current directory, and each page's image will be named using the format `pg_<page_number>.<extension>`.
-Example: A PDF file named document.pdf will generate a folder document, containing images pg_1.png, pg_2.png, etc.
+- Convert PDF files into images where each page is converted into an image. The action will generate a folder named after the PDF file in the current directory, and each page's image will be named using the format `pg_<page_number>.<extension>`. Example: A PDF file named document.pdf will generate a folder document, containing images pg_1.png, pg_2.png, etc.
+- Select multiple images and combine them into a single PDF document.
 
 ## Supported formats
 
@@ -24,6 +24,7 @@ Example: A PDF file named document.pdf will generate a folder document, containi
 | \*.ico, \*.cur                                                     | Microsoft Icon                          |
 | \*.jpg, \*.jpeg, \*.pjpeg, \*.pjp, \*.jpe, \*.jfi, \*.jfif, \*.jif | JPEG (Joint Photographic Experts Group) |
 | \*.jp2, \*.j2k                                                     | JPEG 2000 Image                         |
+| *.jxl                                                              | JPEG XL Image Coding System             |
 | *.pdf                                                              | Portable Document Format                |
 | *.png                                                              | Portable Network Graphics               |
 | *.svg                                                              | plaintext Scalable Vector Graphics      |
@@ -44,22 +45,53 @@ The tool also supports custom resolution (DPI) and allows specifying the range o
 
 ## DEPENDENCIES
 
-The following program must be installed for this action to work:
+### Core
 
-| DEPENDENCY                                                                               | INSTALLATION                            |
-| ---------------------------------------------------------------------------------------- | --------------------------------------- |
-| [convert](https://imagemagick.org/) (from ImageMagick)                                   | `sudo apt-get install -y imagemagick`   |
-| [zenity](https://help.gnome.org/users/zenity/stable/)                                    | `sudo apt-get install -y zenity`        |
-| [file](https://man7.org/linux/man-pages/man1/file.1.html)                                | `sudo apt-get install -y file`          |
-| [rsvg-convert](https://manpages.ubuntu.com/manpages/kinetic/en/man1/rsvg-convert.1.html) | `sudo apt-get install -y librsvg2-bin`  |
-| [pdftoppm](https://linux.die.net/man/1/pdftoppm)                                         | `sudo apt-get install -y poppler-utils` |
-| [xargs](https://linux.die.net/man/1/xargs)                                               | `sudo apt-get install -y findutils`     |
+These tools are essential for the script to function. Most Linux distributions have `file`, `findutils`, and `coreutils` installed by default.
 
-or download the 6 in one go:
+| TOOL                                                                                                   | INSTALLATION                            |
+| :----------------------------------------------------------------------------------------------------- | :-------------------------------------- |
+| **[zenity](https://gitlab.gnome.org/GNOME/zenity)** (GUI Dialogs)                                      | `sudo apt-get install -y zenity`        |
+| **[notify-send](https://manpages.ubuntu.com/manpages/trusty/man1/notify-send.1.html)** (Notifications) | `sudo apt-get install -y libnotify-bin` |
+| **[convert](https://imagemagick.org/)** (ImageMagick)                                                  | `sudo apt-get install -y imagemagick`   |
+| **[pdftoppm](https://linux.die.net/man/1/pdftoppm)** (Poppler)                                         | `sudo apt-get install -y poppler-utils` |
+| **[img2pdf](https://gitlab.mister-muffin.de/josch/img2pdf)** (PDF Merging)                             | `sudo apt-get install -y img2pdf`       |
+| **[file](https://man7.org/linux/man-pages/man1/file.1.html)**                                          | `sudo apt-get install -y file`          |
+| **[xargs](https://linux.die.net/man/1/xargs)** (Findutils)                                             | `sudo apt-get install -y findutils`     |
+| **[cut](https://man7.org/linux/man-pages/man1/cut.1.html)** (Coreutils)                                | `sudo apt-get install -y coreutils`     |
+| **[gzip](https://www.gnu.org/software/gzip/)** (SVGZ Compression)                                      | `sudo apt-get install -y gzip`          |
+
+to install all of them at once, run:
 
 ```sh
 sudo apt-get update
-sudo apt-get install -y imagemagick zenity file librsvg2-bin poppler-utils findutils
+sudo apt-get install -y imagemagick zenity libnotify-bin img2pdf poppler-utils file findutils coreutils gzip
+```
+
+### Format Support & Optional Tools
+
+Install these to enable specific file format conversions
+
+| SUPPORT / FEATURE             | TOOL                                                                                 | INSTALLATION                                 |
+| :---------------------------- | :----------------------------------------------------------------------------------- | :------------------------------------------- |
+| **JPEG XL Support**           | [cjxl / djxl](https://github.com/libjxl/libjxl)                                      | `sudo apt-get install -y libjxl-tools`       |
+| **AVIF Support**              | [avifenc](https://github.com/AOMediaCodec/libavif)                                   | `sudo apt-get install -y libavif-bin`        |
+| **HEIC Conversion**           | [heif-convert](https://manpages.ubuntu.com/manpages/focal/man1/heif-convert.1.html)  | `sudo apt-get install -y libheif-examples`   |
+| **HEIF Library**              | [libheif1](https://github.com/strukturag/libheif)                                    | `sudo apt-get install -y libheif1`           |
+| **JPEG 2000 Support**         | [libopenjp2-7](https://github.com/uclouvain/openjpeg)                                | `sudo apt-get install -y libopenjp2-7`       |
+| **SVG Rasterization**         | [rsvg-convert](https://manpages.ubuntu.com/manpages/bionic/man1/rsvg-convert.1.html) | `sudo apt-get install -y librsvg2-bin`       |
+| **SVG Tracing (Recommended)** | [vtracer](https://github.com/visioncortex/vtracer)                                   | `cargo install vtracer`                      |
+| **SVG Tracing (fallback)**    | [inkscape](https://gitlab.com/inkscape/inkscape)                                     | `sudo apt-get install -y inkscape`           |
+| **SVG Tracing (fallback)**    | [potrace](https://potrace.sourceforge.net/)                                          | `sudo apt-get install -y potrace`            |
+| **PDF/PS Backend**            | [gs](https://ghostscript.com/documentation/)                                         | `sudo apt-get install -y ghostscript`        |
+| **AVIF Thumbnails**           | [libavif-gdk-pixbuf](https://packages.debian.org/sid/libavif-gdk-pixbuf)             | `sudo apt-get install -y libavif-gdk-pixbuf` |
+| **HEIF Thumbnails**           | [heif-gdk-pixbuf](https://packages.debian.org/sid/heif-gdk-pixbuf)                   | `sudo apt-get install -y heif-gdk-pixbuf`    |
+
+to install all of them at once, run:
+
+```sh
+sudo apt-get update
+sudo apt-get install -y libjxl-tools libavif-bin libheif-examples libheif1 libopenjp2-7 librsvg2-bin inkscape potrace ghostscript libavif-gdk-pixbuf heif-gdk-pixbuf
 ```
 
 ## CONTRIBUTING

--- a/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/convert-image-format.sh
+++ b/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/convert-image-format.sh
@@ -1,32 +1,52 @@
 #!/bin/bash
 
+# shellcheck disable=SC2034
 TEXTDOMAIN="convert-image-format@el-amine-404"
 TEXTDOMAINDIR="${HOME}/.local/share/locale"
 
-# Images
+ERR_LOG=$(mktemp)
 
+# shellcheck disable=SC2329
+cleanup() {
+    rm -f "$ERR_LOG"
+}
+trap cleanup EXIT
+
+# ----------------------------------------------------------------------------------------
+# SECTION A: LOCALIZATION STRINGS/KEYS
+# ----------------------------------------------------------------------------------------
+
+# --- Image Context ---
 _IMAGE__TITLE=$"Convert Image(s) Format"
 _IMAGE__PROMPT=$"Choose the format to convert the image(s) to:"
 _IMAGE__COLUMN_1=$"Select"
 _IMAGE__COLUMN_2=$"Format"
 _IMAGE__COLUMN_3=$"Description"
 
+# --- GIF Context ---
+_GIF__MERGE_PROMPT=$"You have selected multiple images and chosen GIF as the format.\n\nDo you want to merge them into a single animated GIF?"
+_GIF__SAVE_TITLE=$"Save GIF As"
+
+# --- VTracer Context ---
+_VT__TITLE=$"Advanced VTracer Options"
+_VT__TEXT=$"Configure how the bitmap is traced into vectors"
+_VT__MODE=$"Mode"
+_VT__COLOR_MODE=$"Color Mode"
+_VT__CLUSTERING=$"Clustering"
+_VT__SPECKLE_FILTER=$"Filter Speckle (Cleaner) [0-128]"
+_VT__COLOR_PRECISION=$"Color Precision (More accurate)"
+_VT__GRADIENT_STEP=$"Gradient Step (Less layers) [0-128]"
+_VT__CURVE_MODE=$"Curve fitting"
+_VT__CORNER_THRESHOLD=$"Corner Threshold (Smoother) [0-180]"
+_VT__SEGMENT_LENGTH=$"Segment Length (More coarse) [3.5-10]"
+_VT__SPLICE_THRESHOLD=$"Splice Threshold (Less accurate) (0-180)"
+_VT__PRESET="Preset"
+
+# --- Progress Context ---
 _PROGRESS_TITLE=$"Converting Images"
 _PROGRESS_TEXT=$"Processing..."
-_NOT_AN_IMAGE=$"is not an image file and will be skipped"
 
-IMAGE__TITLE="$(/usr/bin/gettext "$_IMAGE__TITLE")"
-IMAGE__PROMPT="$(/usr/bin/gettext "$_IMAGE__PROMPT")"
-IMAGE__COLUMN_1="$(/usr/bin/gettext "$_IMAGE__COLUMN_1")"
-IMAGE__COLUMN_2="$(/usr/bin/gettext "$_IMAGE__COLUMN_2")"
-IMAGE__COLUMN_3="$(/usr/bin/gettext "$_IMAGE__COLUMN_3")"
-
-PROGRESS_TITLE="$(/usr/bin/gettext "$_PROGRESS_TITLE")"
-PROGRESS_TEXT="$(/usr/bin/gettext "$_PROGRESS_TEXT")"
-NOT_AN_IMAGE="$(/usr/bin/gettext "$_NOT_AN_IMAGE")"
-
-# PDF
-
+# --- PDF Context ---
 _PDF__TITLE=$"PDF to Image Conversion"
 _PDF__PROMPT=$"Enter the required details for conversion.\n\nNote: Leaving fields empty will apply default values."
 _PDF__COMBO_LABEL=$"Format (default: png)"
@@ -34,7 +54,48 @@ _PDF__COMBO_VALUES="png|jpg|tiff"
 _PDF__ENTRY_1=$"Resolution / DPI (default: 300)"
 _PDF__ENTRY_2=$"First Page (default: 1)"
 _PDF__ENTRY_3=$"Last Page (default: last page of document)"
+_PDF__MERGE_PROMPT=$"You have selected multiple images and chosen PDF as the format.\n\nDo you want to merge them into a single PDF document?\n(Click 'No' to convert them to separate PDF files)"
+_PDF__SAVE_TITLE=$"Save Merged PDF As"
 
+# --- Error & Reporting Context ---
+_ERROR__TITLE=$"Conversion Errors"
+_ERROR__SKIPPED=$"The following files were skipped (unsupported format):"
+_ERR_MISSING_DEP=$"Missing dependency:"
+
+# ----------------------------------------------------------------------------------------
+# SECTION B: LOCALIZATION RESOLUTION
+# ----------------------------------------------------------------------------------------
+
+# --- Image Context ---
+IMAGE__TITLE="$(/usr/bin/gettext "$_IMAGE__TITLE")"
+IMAGE__PROMPT="$(/usr/bin/gettext "$_IMAGE__PROMPT")"
+IMAGE__COLUMN_1="$(/usr/bin/gettext "$_IMAGE__COLUMN_1")"
+IMAGE__COLUMN_2="$(/usr/bin/gettext "$_IMAGE__COLUMN_2")"
+IMAGE__COLUMN_3="$(/usr/bin/gettext "$_IMAGE__COLUMN_3")"
+
+# --- GIF Context ---
+GIF__MERGE_PROMPT="$(/usr/bin/gettext "$_GIF__MERGE_PROMPT")"
+GIF__SAVE_TITLE="$(/usr/bin/gettext "$_GIF__SAVE_TITLE")"
+
+# --- VTracer Context ---
+VT__TITLE="$(/usr/bin/gettext "$_VT__TITLE")"
+VT__TEXT="$(/usr/bin/gettext "$_VT__TEXT")"
+VT__COLOR_MODE="$(/usr/bin/gettext "$_VT__COLOR_MODE")"
+VT__CURVE_MODE="$(/usr/bin/gettext "$_VT__CURVE_MODE")"
+VT__CLUSTERING="$(/usr/bin/gettext "$_VT__CLUSTERING")"
+VT__COLOR_PRECISION="$(/usr/bin/gettext "$_VT__COLOR_PRECISION")"
+VT__SPLICE_THRESHOLD="$(/usr/bin/gettext "$_VT__SPLICE_THRESHOLD")"
+VT__SPECKLE_FILTER="$(/usr/bin/gettext "$_VT__SPECKLE_FILTER")"
+VT__GRADIENT_STEP="$(/usr/bin/gettext "$_VT__GRADIENT_STEP")"
+VT__CORNER_THRESHOLD="$(/usr/bin/gettext "$_VT__CORNER_THRESHOLD")"
+VT__SEGMENT_LENGTH="$(/usr/bin/gettext "$_VT__SEGMENT_LENGTH")"
+VT__PRESET="$(/usr/bin/gettext "$_VT__PRESET")"
+
+# --- Progress Context ---
+PROGRESS_TITLE="$(/usr/bin/gettext "$_PROGRESS_TITLE")"
+PROGRESS_TEXT="$(/usr/bin/gettext "$_PROGRESS_TEXT")"
+
+# --- PDF Context ---
 PDF__TITLE="$(/usr/bin/gettext "$_PDF__TITLE")"
 PDF__PROMPT="$(/usr/bin/gettext "$_PDF__PROMPT")"
 PDF__COMBO_LABEL="$(/usr/bin/gettext "$_PDF__COMBO_LABEL")"
@@ -42,184 +103,487 @@ PDF__COMBO_VALUES="$(/usr/bin/gettext "$_PDF__COMBO_VALUES")"
 PDF__ENTRY_1="$(/usr/bin/gettext "$_PDF__ENTRY_1")"
 PDF__ENTRY_2="$(/usr/bin/gettext "$_PDF__ENTRY_2")"
 PDF__ENTRY_3="$(/usr/bin/gettext "$_PDF__ENTRY_3")"
+PDF__MERGE_PROMPT="$(/usr/bin/gettext "$_PDF__MERGE_PROMPT")"
+PDF__SAVE_TITLE="$(/usr/bin/gettext "$_PDF__SAVE_TITLE")"
 
-_NOT_A_PDF=$"is not a valid PDF file and will be skipped"
-_NOT_A_VALID_FORMAT=$"Unsupported format. Possible values are: png(default), jpeg, tiff"
+# --- Error & Reporting Context ---
+ERROR__TITLE="$(/usr/bin/gettext "$_ERROR__TITLE")"
+ERROR__SKIPPED="$(/usr/bin/gettext "$_ERROR__SKIPPED")"
+ERR_MISSING_DEP="$(/usr/bin/gettext "$_ERR_MISSING_DEP")"
 
-NOT_A_PDF="$(/usr/bin/gettext "$_NOT_A_PDF")"
-NOT_A_VALID_FORMAT="$(/usr/bin/gettext "$_NOT_A_VALID_FORMAT")"
+# ------------------------------------------------------------------------------
+# SECTION C: CORE FUNCTIONS
+# ------------------------------------------------------------------------------
 
-# i removed the raw formats bc as far as i know you can not convert from other formats
-# to raw formats (the reverse operation is possible) right? RIGHT? 😢
-# + raw, arw, cr, cr2, nef, orf, sr2, rw2, nrw, k25, 3fr
-#
-# other formats need a more complex script so i removed them from the selection:
-# FALSE "eps" "Encapsulated PostScript" \
-# FALSE "ai" "Adobe Illustrator Document" \
-# FALSE "tga" "Targa Image File" \
-# FALSE "hdr" "High Dynamic Range Image" \
-# FALSE "pcx" "PC Paintbrush Bitmap Image" \
-# FALSE "psd" "Photoshop Document" \
+check_dependencies() {
+    if ! command -v zenity &> /dev/null; then
+        if command -v notify-send &> /dev/null; then
+            /usr/bin/notify-send "Error" "The program 'zenity' is required." -u critical
+        fi
+        exit 1
+    fi
 
-# full path to the selected file
-FILE="$1"
-# directory where the generated image will be saved
-DIRECTORY=$(dirname "$1")
+    # only essential dependencies, others can be installed later if the user wants to:
+    local deps=("convert" "file" "pdftoppm" "xargs" "cut")
+    for cmd in "${deps[@]}"; do
+        if ! command -v "$cmd" &> /dev/null; then
+            /usr/bin/zenity --error --text="${ERR_MISSING_DEP} $cmd"
+            exit 1
+        fi
+    done
+}
+
+verify_tool() {
+    local cmd="$1"
+    local feature_name="$2"
+    if ! command -v "$cmd" &> /dev/null; then
+        log_error "DEPENDENCY" "Missing tool '$cmd'. Required for: $feature_name"
+        return 1
+    fi
+    return 0
+}
+
+get_safe_path() {
+    local full_path="$1"
+    local dir
+    dir=$(dirname "$full_path")
+    local filename
+    filename=$(basename "$full_path")
+    local ext="${filename##*.}"
+    local name="${filename%.*}"
+
+    local new_path="$full_path"
+    local counter=1
+
+    while [ -e "$new_path" ]; do
+        new_path="${dir}/${name}_${counter}.${ext}"
+        counter=$((counter + 1))
+    done
+
+    echo "$new_path"
+}
+
+log_error() {
+    local file="$1"
+    local msg="$2"
+    {
+        printf '%s\n' "--------------------------------------------------"
+        printf 'FILE:  %s\n' "$(basename "$file")"
+        printf 'ERROR: %s\n' "$msg"
+    } >> "$ERR_LOG"
+}
+
+get_image_target_format() {
+    /usr/bin/zenity --list --radiolist \
+        --title="$IMAGE__TITLE" \
+        --text="$IMAGE__PROMPT" \
+        --height=320 \
+        --width=640 \
+        --column="$IMAGE__COLUMN_1" --column="$IMAGE__COLUMN_2" --column="$IMAGE__COLUMN_3" \
+        FALSE "apng" "Animated Portable Network Graphics" \
+        FALSE "avif" "AV1 Image File Format" \
+        FALSE "bmp" "Bitmap" \
+        FALSE "cur" "Microsoft Icon" \
+        FALSE "gif" "Graphics Interchange Format" \
+        FALSE "heic" "High Efficiency Image Coding" \
+        FALSE "heif" "High Efficiency Image Format" \
+        FALSE "ico" "Microsoft Icon" \
+        FALSE "j2k" "JPEG 2000 Code Stream" \
+        FALSE "jfi" "JPEG (Joint Photographic Experts Group)" \
+        FALSE "jfif" "JPEG (Joint Photographic Experts Group)" \
+        FALSE "jif" "JPEG (Joint Photographic Experts Group)" \
+        FALSE "jp2" "JPEG 2000 Image" \
+        FALSE "jpe" "JPEG (Joint Photographic Experts Group)" \
+        FALSE "jpeg" "JPEG (Joint Photographic Experts Group)" \
+        FALSE "jpg" "JPEG (Joint Photographic Experts Group)" \
+        FALSE "jxl" "JPEG XL Image Coding System" \
+        FALSE "pjp" "JPEG (Joint Photographic Experts Group)" \
+        FALSE "pjpeg" "JPEG (Joint Photographic Experts Group)" \
+        FALSE "pdf" "Portable Document Format" \
+        FALSE "png" "Portable Network Graphics" \
+        FALSE "svg" "plaintext Scalable Vector Graphics" \
+        FALSE "svgz" "compressed Scalable Vector Graphics" \
+        FALSE "tif" "Tagged Image File Format" \
+        FALSE "tiff" "Tagged Image File Format" \
+        FALSE "webp" "Web Picture format"
+}
+
+get_vtracer_settings() {
+
+    /usr/bin/zenity --forms \
+        --title="$VT__TITLE" \
+        --text="$VT__TEXT" \
+        --separator="|" \
+        --add-combo="$VT__COLOR_MODE" --combo-values="|color|bw" \
+        --add-combo="$VT__COLOR_PRECISION" --combo-values="|1|2|3|4|5|6|7|8" \
+        --add-combo="$VT__PRESET" --combo-values="|bw|poster|photo" \
+        --add-combo="$VT__CLUSTERING" --combo-values="|stacked|cutout" \
+        --add-entry="$VT__SPECKLE_FILTER" \
+        --add-entry="$VT__GRADIENT_STEP" \
+        --add-combo="$VT__CURVE_MODE" --combo-values="|spline|polygon|pixel" \
+        --add-entry="$VT__CORNER_THRESHOLD" \
+        --add-entry="$VT__SEGMENT_LENGTH" \
+        --add-entry="$VT__SPLICE_THRESHOLD"
+
+}
+
+convert_to_svg() {
+    local file="$1"
+    local safe_target="$2"
+    local settings="$3"
+    local output_msg=""
+
+    if command -v vtracer &> /dev/null; then
+        [ -z "$settings" ] && return 1
+
+        local cmd_vtracer=("vtracer" "--input" "$file" "--output" "$safe_target")
+
+        IFS='|' read -r VAL_COLORMODE VAL_PRECISION VAL_PRESET VAL_CLUSTERING VAL_SPECKLE VAL_GRADIENTSTEP VAL_MODE VAL_CORNER VAL_SEGMENT VAL_SPLICETHRESHOLD <<< "$settings"
+
+        check_and_add() {
+            local flag="$1"
+            local value
+            value=$(echo "$2" | xargs)
+            [[ -n "$value" ]] && cmd_vtracer+=("$flag" "$value")
+        }
+
+        check_and_add "--colormode" "$VAL_COLORMODE"
+        check_and_add "--color_precision" "$VAL_PRECISION"
+        check_and_add "--preset" "$VAL_PRESET"
+        check_and_add "--hierarchical" "$VAL_CLUSTERING"
+        check_and_add "--filter_speckle" "$VAL_SPECKLE"
+        check_and_add "--gradient_step" "$VAL_GRADIENTSTEP"
+        check_and_add "--mode" "$VAL_MODE"
+        check_and_add "--corner_threshold" "$VAL_CORNER"
+        check_and_add "--segment_length" "$VAL_SEGMENT"
+        check_and_add "--splice_threshold" "$VAL_SPLICETHRESHOLD"
+
+        if output_msg=$("${cmd_vtracer[@]}" 2>&1); then
+            return 0
+        else
+            log_error "$file" "VTracer Failed: $output_msg"
+            return 1
+        fi
+    fi
+
+    if command -v inkscape &> /dev/null; then
+        if output_msg=$(inkscape "$file" --export-filename="$safe_target" 2>&1); then
+            return 0
+        else
+            log_error "$file" "Inkscape Failed: $output_msg"
+            return 1
+        fi
+    fi
+
+    if command -v potrace &> /dev/null; then
+        if output_msg=$(
+            set -o pipefail
+            convert "$file" pnm:- | potrace -s -o "$safe_target" - 2>&1
+        ); then
+            return 0
+        else
+            log_error "$file" "Potrace/ImageMagick Failed: $output_msg"
+            return 1
+        fi
+    fi
+
+    log_error "$file" "No suitable SVG converter found (vtracer, potrace, or inkscape missing/failed).\nLast Error: $output_msg"
+    return 1
+}
+
+get_pdf_settings() {
+    /usr/bin/zenity --forms \
+        --title="$PDF__TITLE" \
+        --text="$PDF__PROMPT" \
+        --add-combo="$PDF__COMBO_LABEL" --combo-values="$PDF__COMBO_VALUES" \
+        --add-entry="$PDF__ENTRY_1" \
+        --add-entry="$PDF__ENTRY_2" \
+        --add-entry="$PDF__ENTRY_3" \
+        --separator="|"
+}
 
 convert_image() {
+    local file="$1"
+    local target_ext="$2"
+    local vt_settings="$3"
+    local output_msg=""
+    local rc=0
 
-  if ! EXTENSION=$(
-    /usr/bin/zenity --list --radiolist \
-      --title="$IMAGE__TITLE" \
-      --text="$IMAGE__PROMPT" \
-      --height=320 \
-      --width=640 \
-      --column="$IMAGE__COLUMN_1" --column="$IMAGE__COLUMN_2" --column="$IMAGE__COLUMN_3" \
-      FALSE "apng" "Animated Portable Network Graphics" \
-      FALSE "avif" "AV1 Image File Format" \
-      FALSE "bmp" "Bitmap" \
-      FALSE "cur" "Microsoft Icon" \
-      FALSE "gif" "Graphics Interchange Format" \
-      FALSE "heic" "High Efficiency Image Coding" \
-      FALSE "heif" "High Efficiency Image Format" \
-      FALSE "ico" "Microsoft Icon" \
-      FALSE "j2k" "JPEG 2000 Code Stream" \
-      FALSE "jfi" "JPEG (Joint Photographic Experts Group)" \
-      FALSE "jfif" "JPEG (Joint Photographic Experts Group)" \
-      FALSE "jif" "JPEG (Joint Photographic Experts Group)" \
-      FALSE "jp2" "JPEG 2000 Image" \
-      FALSE "jpe" "JPEG (Joint Photographic Experts Group)" \
-      FALSE "jpeg" "JPEG (Joint Photographic Experts Group)" \
-      FALSE "jpg" "JPEG (Joint Photographic Experts Group)" \
-      FALSE "pjp" "JPEG (Joint Photographic Experts Group)" \
-      FALSE "pjpeg" "JPEG (Joint Photographic Experts Group)" \
-      FALSE "pdf" "Portable Document Format" \
-      FALSE "png" "Portable Network Graphics" \
-      FALSE "svg" "plaintext Scalable Vector Graphics" \
-      FALSE "svgz" "compressed Scalable Vector Graphics" \
-      FALSE "tif" "Tagged Image File Format" \
-      FALSE "tiff" "Tagged Image File Format" \
-      FALSE "webp" "Web Picture format"
-  ); then
-    exit
-  fi
+    local dir
+    dir=$(dirname "$file")
+    local filename
+    filename=$(basename "$file")
+    local basename="${filename%.*}"
+    local source_ext="${filename##*.}"
+    source_ext="${source_ext,,}"
 
-  local FILE="$1"
-  if [[ "${FILE##*.}" == "psd" ]]; then
-    /usr/bin/convert "${FILE}[0]" -set filename:basename "%[basename]" "${DIRECTORY}/%[filename:basename].${EXTENSION}"
-  elif [[ "${FILE##*.}" == "gif" ]]; then
-    /usr/bin/convert "$FILE" -set filename:basename "%[basename]" "${DIRECTORY}/%[filename:basename]_frame_%05d.${EXTENSION}"
-  elif [[ "${FILE##*.}" == "svg" && ("$EXTENSION" == "eps" || "$EXTENSION" == "pdf" || "$EXTENSION" == "png" || "$EXTENSION" == "ps" || "$EXTENSION" == "svg") ]]; then
-    /usr/bin/rsvg-convert --format="$EXTENSION" --output="${FILE%.*}.${EXTENSION}" "$FILE"
-  else
-    /usr/bin/convert "$FILE" -set filename:basename "%[basename]" "${DIRECTORY}/%[filename:basename].${EXTENSION}"
-  fi
+    local target_file="${dir}/${basename}.${target_ext}"
+    local safe_target
+    safe_target=$(get_safe_path "$target_file")
+
+    if [[ "$target_ext" =~ ^(svg|svgz)$ ]]; then
+        if [[ "$target_ext" == "svgz" ]]; then
+            local temp_svg="${safe_target%.*}.temp.svg"
+            if convert_to_svg "$file" "$temp_svg" "$vt_settings"; then
+                gzip -c "$temp_svg" > "$safe_target"
+                rm -f "$temp_svg"
+            else
+                return 1
+            fi
+        else
+            convert_to_svg "$file" "$safe_target" "$vt_settings"
+        fi
+        return
+    fi
+
+    if [[ "$target_ext" == "jxl" ]]; then
+        verify_tool "cjxl" "JPEG XL Encoding" || return 1
+        output_msg=$(/usr/bin/convert "$file" png:- | /usr/bin/cjxl - "$safe_target" 2>&1)
+        rc=$?
+
+    elif [[ "$source_ext" == "jxl" ]]; then
+        verify_tool "djxl" "JPEG XL Decoding" || return 1
+        output_msg=$(/usr/bin/djxl "$file" - | /usr/bin/convert - "$safe_target" 2>&1)
+        rc=$?
+
+    elif [[ "$source_ext" == "psd" ]]; then
+        output_msg=$(/usr/bin/convert "${file}[0]" "$safe_target" 2>&1)
+        rc=$?
+
+    elif [[ "$source_ext" == "gif" ]]; then
+        local safe_base="${safe_target%.*}"
+        output_msg=$(/usr/bin/convert "$file" -coalesce "${safe_base}_frame_%05d.${target_ext}" 2>&1)
+        rc=$?
+
+    elif [[ "$source_ext" == "svg" ]] && [[ "$target_ext" =~ ^(eps|pdf|png|ps|svg)$ ]]; then
+        verify_tool "rsvg-convert" "Better SVG Conversion" || return 1
+        output_msg=$(/usr/bin/rsvg-convert --format="$target_ext" --output="$safe_target" "$file" 2>&1)
+        rc=$?
+
+    else
+        output_msg=$(/usr/bin/convert "$file" "$safe_target" 2>&1)
+        rc=$?
+    fi
+
+    if [ "$rc" -ne 0 ]; then
+        log_error "$file" "$output_msg"
+    fi
+}
+
+create_animated_gif() {
+    local first_file="${IMAGES_LIST[0]}"
+    local default_dir
+    default_dir=$(dirname "$first_file")
+    local output_msg=""
+
+    OUTPUT_FILE=$(/usr/bin/zenity --file-selection --save --confirm-overwrite \
+        --title="$GIF__SAVE_TITLE" \
+        --filename="${default_dir}/animation.gif")
+
+    if [ -z "$OUTPUT_FILE" ]; then return; fi
+
+    if [[ "${OUTPUT_FILE##*.}" != "gif" ]]; then
+        OUTPUT_FILE="${OUTPUT_FILE}.gif"
+    fi
+
+    (
+        if ! output_msg=$(/usr/bin/convert -delay 20 -loop 0 "${IMAGES_LIST[@]}" "$OUTPUT_FILE" 2>&1); then
+            log_error "Animated GIF Merge" "$output_msg"
+        fi
+    ) | /usr/bin/zenity --progress --title="$PROGRESS_TITLE" --pulsate --auto-close
 }
 
 convert_pdf() {
+    local file="$1"
+    local settings="$2"
+    local output_msg=""
 
-  if [ -z "$1" ]; then
-    echo "Error: File argument is required."
-    return 1
-  fi
+    verify_tool "pdftoppm" "PDF to Image" || return 1
 
-  if ! PDF_INFO=$(
-    /usr/bin/zenity --forms \
-      --title="$PDF__TITLE" \
-      --text="$PDF__PROMPT" \
-      --add-combo="$PDF__COMBO_LABEL" --combo-values="$PDF__COMBO_VALUES" \
-      --add-entry="$PDF__ENTRY_1" \
-      --add-entry="$PDF__ENTRY_2" \
-      --add-entry="$PDF__ENTRY_3" \
-      --separator="|"
-  ); then
-    exit
-  fi
+    local p_fmt
+    p_fmt=$(echo "$settings" | cut -d "|" -f1 | xargs)
+    local p_dpi
+    p_dpi=$(echo "$settings" | cut -d "|" -f2 | xargs)
+    local p_start
+    p_start=$(echo "$settings" | cut -d "|" -f3 | xargs)
+    local p_end
+    p_end=$(echo "$settings" | cut -d "|" -f4 | xargs)
 
-  local file="$1"
+    p_fmt="${p_fmt:-png}"
+    p_dpi="${p_dpi:-300}"
+    p_start="${p_start:-1}"
 
-  # Parse the information returned from zenity
-  # xargs is used to strip whitespace :)
-  format=$(echo "$PDF_INFO" | cut -d "|" -f1 | xargs)
-  resolution=$(echo "$PDF_INFO" | cut -d "|" -f2 | xargs)
-  firstpage=$(echo "$PDF_INFO" | cut -d "|" -f3 | xargs)
-  lastpage=$(echo "$PDF_INFO" | cut -d "|" -f4 | xargs)
+    if [[ -z "$p_end" ]] && command -v pdfinfo &> /dev/null; then
+        p_end=$(pdfinfo "$file" | grep '^Pages:' | awk '{print $2}')
+    fi
 
-  # Set default values if arguments are not provided
-  format="${format:-png}"
-  resolution="${resolution:-300}"
-  firstpage="${firstpage:-1}"
-  # Calculate last page if not provided
-  if [ -z "$lastpage" ]; then
-    lastpage=$(pdfinfo "$file" | grep '^Pages:' | awk '{print $2}')
-  fi
+    local fmt_flag=""
+    case "$p_fmt" in
+        "jpg" | "jpeg") fmt_flag="-jpeg" ;;
+        "png") fmt_flag="-png" ;;
+        "tiff" | "tif") fmt_flag="-tiff" ;;
+        *) return 1 ;;
+    esac
 
-  # Create directory based on the filename
-  # directory where the generated image will be saved
-  FILE_NAME=$(basename "$file" .pdf)
+    local dir
+    dir=$(dirname "$file")
+    local bname
+    bname=$(basename "$file" .pdf)
 
-  [ ! -d "${DIRECTORY}/images_${FILE_NAME}" ] && mkdir -pv "${DIRECTORY}/images_${FILE_NAME}"
+    local raw_out_dir="${dir}/${bname}_images"
+    local safe_out_dir="$raw_out_dir"
+    local counter=1
+    while [ -d "$safe_out_dir" ]; do
+        safe_out_dir="${raw_out_dir}_${counter}"
+        counter=$((counter + 1))
+    done
+    mkdir -pv "$safe_out_dir"
 
-  # Determine format options based on provided format
-  case "$format" in
-  "jpg") format_options="-jpeg" ;;
-  "png") format_options="-png" ;;
-  "tiff") format_options="-tiff" ;;
-  *)
-    /usr/bin/zenity --warning --text="$NOT_A_VALID_FORMAT"
-    return 1
-    ;;
-  esac
+    local args=(
+        "$fmt_flag"
+        "-r" "$p_dpi"
+        "-f" "$p_start"
+        "-forcenum"
+        "-sep" "_"
+    )
+    if [[ -n "$p_end" ]]; then args+=("-l" "$p_end"); fi
 
-  pdftoppm \
-    "${format_options}" \
-    -forcenum \
-    -sep _ \
-    -r "$resolution" \
-    -f "$firstpage" \
-    -l "$lastpage" \
-    "$file" \
-    "${DIRECTORY}/images_${FILE_NAME}/pg"
-
+    if ! output_msg=$(pdftoppm "${args[@]}" "$file" "${safe_out_dir}/pg" 2>&1); then
+        log_error "$file" "$output_msg"
+    fi
 }
 
-(
-  if [ "$EXTENSION" == "gif" ]; then
-    /usr/bin/convert -delay 20 -loop 0 "$@" "${DIRECTORY}/output.gif"
-    exit 0
-  fi
-) | /usr/bin/zenity --progress \
-  --title="$IMAGE__PROGRESS_TITLE" \
-  --text="$IMAGE__PROGRESS_TEXT" \
-  --pulsate \
-  --auto-close
+create_merged_pdf() {
+    local first_file="${IMAGES_LIST[0]}"
+    local default_dir
+    default_dir=$(dirname "$first_file")
+    local output_msg=""
 
-if [ "$EXTENSION" == "gif" ]; then
-  exit 0
+    verify_tool "img2pdf" "Merge Images to PDF" || return 1
+
+    OUTPUT_FILE=$(/usr/bin/zenity --file-selection --save --confirm-overwrite \
+        --title="$PDF__SAVE_TITLE" \
+        --filename="${default_dir}/merged_images.pdf")
+
+    if [ -z "$OUTPUT_FILE" ]; then return; fi
+
+    if [[ "${OUTPUT_FILE##*.}" != "pdf" ]]; then
+        OUTPUT_FILE="${OUTPUT_FILE}.pdf"
+    fi
+
+    (
+        if ! output_msg=$(/usr/bin/img2pdf "${IMAGES_LIST[@]}" --output "$OUTPUT_FILE" 2>&1); then
+            log_error "PDF Merge" "$output_msg"
+        fi
+    ) | /usr/bin/zenity --progress --title="$PROGRESS_TITLE" --pulsate --auto-close
+}
+
+# ------------------------------------------------------------------------------
+# SECTION D: MAIN
+# ------------------------------------------------------------------------------
+
+check_dependencies
+
+declare -a IMAGES_LIST
+declare -a PDFS_LIST
+declare -a SKIPPED_LIST
+
+for file in "$@"; do
+    mime=$(file --mime-type -b "$file")
+    if [[ "$mime" == image/* ]]; then
+        IMAGES_LIST+=("$file")
+    elif [[ "$mime" == application/pdf ]]; then
+        PDFS_LIST+=("$file")
+    else
+        SKIPPED_LIST+=("$file")
+    fi
+done
+
+TARGET_IMG_EXT=""
+PDF_SETTINGS=""
+VT_SETTINGS=""
+
+if [ ${#IMAGES_LIST[@]} -gt 0 ]; then
+    TARGET_IMG_EXT=$(get_image_target_format)
+    [ -z "$TARGET_IMG_EXT" ] && exit 0
+
+    if [[ "$TARGET_IMG_EXT" == "gif" && ${#IMAGES_LIST[@]} -gt 1 ]]; then
+        if /usr/bin/zenity --question --text="$GIF__MERGE_PROMPT"; then
+            create_animated_gif
+            IMAGES_LIST=()
+        fi
+    fi
+
+    if [[ "$TARGET_IMG_EXT" == "svg" || "$TARGET_IMG_EXT" == "svgz" ]]; then
+        if command -v vtracer &> /dev/null; then
+            VT_SETTINGS=$(get_vtracer_settings)
+            [ -z "$VT_SETTINGS" ] && exit 0
+        fi
+    fi
+
+    if [[ "$TARGET_IMG_EXT" == "pdf" && ${#IMAGES_LIST[@]} -gt 1 ]]; then
+
+        if /usr/bin/zenity --question \
+            --text="$PDF__MERGE_PROMPT" \
+            --ok-label="Merge into single PDF" \
+            --cancel-label="Keep separate PDFs"; then
+
+            create_merged_pdf
+            IMAGES_LIST=()
+        fi
+    fi
 fi
 
+if [ ${#PDFS_LIST[@]} -gt 0 ]; then
+    PDF_SETTINGS=$(get_pdf_settings)
+    [ -z "$PDF_SETTINGS" ] && exit 0
+fi
+
+TOTAL_FILES=$((${#IMAGES_LIST[@]} + ${#PDFS_LIST[@]}))
+CURRENT=0
+
 (
-  TOTAL_FILES=$#
-  COUNT=0
-  for FILE in "$@"; do
-    MIMETYPE=$(/usr/bin/file --mime-type -b "$FILE")
-    if [[ $MIMETYPE == image/* ]]; then
-      convert_image "$FILE"
-      COUNT=$((COUNT + 1))
-      echo "$((COUNT * 100 / TOTAL_FILES))"
-      echo "# Converting $FILE ($COUNT of $TOTAL_FILES)"
-    elif [[ $MIMETYPE == application/pdf ]]; then
-      convert_pdf "$FILE"
-      COUNT=$((COUNT + 1))
-      echo "$((COUNT * 100 / TOTAL_FILES))"
-      echo "# Converting $FILE ($COUNT of $TOTAL_FILES)"
-    else
-      [[ $MIMETYPE == image/* ]] && /usr/bin/zenity --warning --text="$FILE $NOT_AN_IMAGE."
-      [[ $MIMETYPE == application/pdf ]] && /usr/bin/zenity --warning --text="$FILE $NOT_A_PDF."
+    if [ ${#IMAGES_LIST[@]} -gt 0 ]; then
+        for img in "${IMAGES_LIST[@]}"; do
+            echo "# Converting: $(basename "$img")"
+            convert_image "$img" "$TARGET_IMG_EXT" "$VT_SETTINGS"
+            CURRENT=$((CURRENT + 1))
+            echo $((CURRENT * 100 / TOTAL_FILES))
+        done
     fi
-  done
+
+    if [ ${#PDFS_LIST[@]} -gt 0 ]; then
+        for pdf in "${PDFS_LIST[@]}"; do
+            echo "# Extracting PDF: $(basename "$pdf")"
+            convert_pdf "$pdf" "$PDF_SETTINGS"
+            CURRENT=$((CURRENT + 1))
+            echo $((CURRENT * 100 / TOTAL_FILES))
+        done
+    fi
+
 ) | /usr/bin/zenity --progress \
-  --title="$PROGRESS_TITLE" \
-  --text="$PROGRESS_TEXT" \
-  --percentage=0 \
-  --auto-close
+    --title="$PROGRESS_TITLE" \
+    --text="$PROGRESS_TEXT" \
+    --percentage=0 \
+    --auto-close
+
+if [ -s "$ERR_LOG" ]; then
+    /usr/bin/zenity --text-info \
+        --title="$ERROR__TITLE" \
+        --filename="$ERR_LOG" \
+        --width=600 --height=400 \
+        --font="Monospace"
+fi
+
+if [ ${#SKIPPED_LIST[@]} -gt 0 ]; then
+    skipped_names=""
+    for f in "${SKIPPED_LIST[@]}"; do
+        skipped_names+="$(basename "$f")\n"
+    done
+    /usr/bin/zenity --warning \
+        --title="$ERROR__TITLE" \
+        --text="$ERROR__SKIPPED\n\n$skipped_names" \
+        --width=400
+fi
+
+exit 0

--- a/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/metadata.json
+++ b/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/metadata.json
@@ -3,5 +3,5 @@
   "uuid": "convert-image-format@el-amine-404",
   "name": "Convert Image Format",
   "author": "el-amine-404",
-  "version": "0.1.0"
+  "version": "0.2.0"
 }

--- a/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/bg.po
+++ b/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/bg.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: convert-image-format@el-amine-404 0.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2025-02-17 16:47-0500\n"
+"POT-Creation-Date: 2026-01-31 12:13+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -23,43 +23,97 @@ msgstr ""
 msgid "Convert Image Format"
 msgstr "Конвертиране формата на изображение"
 
-#. convert-image-format.sh:8
+#. convert-image-format.sh:19
 msgid "Convert Image(s) Format"
 msgstr "Конвертиране формата на изображение(я)"
 
-#. convert-image-format.sh:9
+#. convert-image-format.sh:20
 msgid "Choose the format to convert the image(s) to:"
 msgstr "Избор на формат за конвертиране на изображение(я):"
 
-#. convert-image-format.sh:10
+#. convert-image-format.sh:21
 msgid "Select"
 msgstr "Избор"
 
-#. convert-image-format.sh:11
+#. convert-image-format.sh:22
 msgid "Format"
 msgstr "Формат"
 
-#. convert-image-format.sh:12
+#. convert-image-format.sh:23
 msgid "Description"
 msgstr "Описание"
 
-#. convert-image-format.sh:14
+#. convert-image-format.sh:26
+msgid ""
+"You have selected multiple images and chosen GIF as the format.\\n\\nDo you "
+"want to merge them into a single animated GIF?"
+msgstr ""
+
+#. convert-image-format.sh:27
+msgid "Save GIF As"
+msgstr ""
+
+#. convert-image-format.sh:30
+msgid "Advanced VTracer Options"
+msgstr ""
+
+#. convert-image-format.sh:31
+msgid "Configure how the bitmap is traced into vectors"
+msgstr ""
+
+#. convert-image-format.sh:32
+msgid "Mode"
+msgstr ""
+
+#. convert-image-format.sh:33
+msgid "Color Mode"
+msgstr ""
+
+#. convert-image-format.sh:34
+msgid "Clustering"
+msgstr ""
+
+#. convert-image-format.sh:35
+msgid "Filter Speckle (Cleaner) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:36
+msgid "Color Precision (More accurate)"
+msgstr ""
+
+#. convert-image-format.sh:37
+msgid "Gradient Step (Less layers) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:38
+msgid "Curve fitting"
+msgstr ""
+
+#. convert-image-format.sh:39
+msgid "Corner Threshold (Smoother) [0-180]"
+msgstr ""
+
+#. convert-image-format.sh:40
+msgid "Segment Length (More coarse) [3.5-10]"
+msgstr ""
+
+#. convert-image-format.sh:41
+msgid "Splice Threshold (Less accurate) (0-180)"
+msgstr ""
+
+#. convert-image-format.sh:45
 msgid "Converting Images"
 msgstr "Конвертиране на изображения"
 
-#. convert-image-format.sh:15
+#. convert-image-format.sh:46
 msgid "Processing..."
 msgstr "Обработка..."
 
-#. convert-image-format.sh:16
-msgid "is not an image file and will be skipped"
-msgstr "не е файл с изображение и ще бъде пропуснат"
-
-#. convert-image-format.sh:30
+#. convert-image-format.sh:49
 msgid "PDF to Image Conversion"
 msgstr "Преобразуване на PDF в изображение"
 
-#. convert-image-format.sh:31
+#. convert-image-format.sh:50
 msgid ""
 "Enter the required details for conversion.\\n\\nNote: Leaving fields empty "
 "will apply default values."
@@ -67,30 +121,44 @@ msgstr ""
 "Въведете нужните детайли за преобразуване.\\n\\Бележка: Ако оставите "
 "полетата празни ще бъдат приложени стандартните стойности."
 
-#. convert-image-format.sh:32
+#. convert-image-format.sh:51
 msgid "Format (default: png)"
 msgstr "Формат (стандартно: png)"
 
-#. convert-image-format.sh:34
+#. convert-image-format.sh:53
 msgid "Resolution / DPI (default: 300)"
 msgstr "Резолюция / DPI (стандартно: 300)"
 
-#. convert-image-format.sh:35
+#. convert-image-format.sh:54
 msgid "First Page (default: 1)"
 msgstr "Първа страница (стандартно: 1)"
 
-#. convert-image-format.sh:36
+#. convert-image-format.sh:55
 msgid "Last Page (default: last page of document)"
 msgstr "Последна страница (стандартно: последна страница от документа)"
 
-#. convert-image-format.sh:46
-msgid "is not a valid PDF file and will be skipped"
-msgstr "не е валиден PDF файл и ще бъде пропуснат"
-
-#. convert-image-format.sh:47
-msgid "Unsupported format. Possible values are: png(default), jpeg, tiff"
+#. convert-image-format.sh:56
+msgid ""
+"You have selected multiple images and chosen PDF as the format.\\n\\nDo you "
+"want to merge them into a single PDF document?\\n(Click 'No' to convert them "
+"to separate PDF files)"
 msgstr ""
-"Неподдържан формат. Възможните стойности са: png (стандартно), jpeg, tiff"
+
+#. convert-image-format.sh:57
+msgid "Save Merged PDF As"
+msgstr ""
+
+#. convert-image-format.sh:60
+msgid "Conversion Errors"
+msgstr ""
+
+#. convert-image-format.sh:61
+msgid "The following files were skipped (unsupported format):"
+msgstr ""
+
+#. convert-image-format.sh:62
+msgid "Missing dependency:"
+msgstr ""
 
 #. convert-image-format@el-amine-404.nemo_action.in->Name
 msgid "Convert image(s) to another format"

--- a/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/ca.po
+++ b/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: convert-image-format@el-amine-404 0.0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2025-02-17 16:47-0500\n"
+"POT-Creation-Date: 2026-01-31 12:13+0100\n"
 "PO-Revision-Date: 2024-09-17 02:12+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -23,43 +23,97 @@ msgstr ""
 msgid "Convert Image Format"
 msgstr "Converteix el format de la imatge"
 
-#. convert-image-format.sh:8
+#. convert-image-format.sh:19
 msgid "Convert Image(s) Format"
 msgstr "Converteix el format de la/les imatge(s)"
 
-#. convert-image-format.sh:9
+#. convert-image-format.sh:20
 msgid "Choose the format to convert the image(s) to:"
 msgstr "Tria el format a convertir la/les imatge(s) a:"
 
-#. convert-image-format.sh:10
+#. convert-image-format.sh:21
 msgid "Select"
 msgstr "Selecciona"
 
-#. convert-image-format.sh:11
+#. convert-image-format.sh:22
 msgid "Format"
 msgstr "Format"
 
-#. convert-image-format.sh:12
+#. convert-image-format.sh:23
 msgid "Description"
 msgstr "Descripció"
 
-#. convert-image-format.sh:14
+#. convert-image-format.sh:26
+msgid ""
+"You have selected multiple images and chosen GIF as the format.\\n\\nDo you "
+"want to merge them into a single animated GIF?"
+msgstr ""
+
+#. convert-image-format.sh:27
+msgid "Save GIF As"
+msgstr ""
+
+#. convert-image-format.sh:30
+msgid "Advanced VTracer Options"
+msgstr ""
+
+#. convert-image-format.sh:31
+msgid "Configure how the bitmap is traced into vectors"
+msgstr ""
+
+#. convert-image-format.sh:32
+msgid "Mode"
+msgstr ""
+
+#. convert-image-format.sh:33
+msgid "Color Mode"
+msgstr ""
+
+#. convert-image-format.sh:34
+msgid "Clustering"
+msgstr ""
+
+#. convert-image-format.sh:35
+msgid "Filter Speckle (Cleaner) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:36
+msgid "Color Precision (More accurate)"
+msgstr ""
+
+#. convert-image-format.sh:37
+msgid "Gradient Step (Less layers) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:38
+msgid "Curve fitting"
+msgstr ""
+
+#. convert-image-format.sh:39
+msgid "Corner Threshold (Smoother) [0-180]"
+msgstr ""
+
+#. convert-image-format.sh:40
+msgid "Segment Length (More coarse) [3.5-10]"
+msgstr ""
+
+#. convert-image-format.sh:41
+msgid "Splice Threshold (Less accurate) (0-180)"
+msgstr ""
+
+#. convert-image-format.sh:45
 msgid "Converting Images"
 msgstr "Convertint imatges"
 
-#. convert-image-format.sh:15
+#. convert-image-format.sh:46
 msgid "Processing..."
 msgstr "Processant..."
 
-#. convert-image-format.sh:16
-msgid "is not an image file and will be skipped"
-msgstr "no és un fitxer d'imatge i serà ignorat"
-
-#. convert-image-format.sh:30
+#. convert-image-format.sh:49
 msgid "PDF to Image Conversion"
 msgstr "Conversió de PDF a Imatge"
 
-#. convert-image-format.sh:31
+#. convert-image-format.sh:50
 msgid ""
 "Enter the required details for conversion.\\n\\nNote: Leaving fields empty "
 "will apply default values."
@@ -67,30 +121,44 @@ msgstr ""
 "Introdueix els detalls necessaris per a la conversió.\\n\\nNota: deixar "
 "camps buits aplicarà els valors per defecte."
 
-#. convert-image-format.sh:32
+#. convert-image-format.sh:51
 msgid "Format (default: png)"
 msgstr "Format (per defecte: png)"
 
-#. convert-image-format.sh:34
+#. convert-image-format.sh:53
 msgid "Resolution / DPI (default: 300)"
 msgstr "Resolució / DPI (per defecte: 300)"
 
-#. convert-image-format.sh:35
+#. convert-image-format.sh:54
 msgid "First Page (default: 1)"
 msgstr "Primera pàgina (per defecte: 1)"
 
-#. convert-image-format.sh:36
+#. convert-image-format.sh:55
 msgid "Last Page (default: last page of document)"
 msgstr "Última pàgina (per defecte: última pàgina del document)"
 
-#. convert-image-format.sh:46
-msgid "is not a valid PDF file and will be skipped"
-msgstr "no és un fitxer PDF vàlid i serà ignorat"
-
-#. convert-image-format.sh:47
-msgid "Unsupported format. Possible values are: png(default), jpeg, tiff"
+#. convert-image-format.sh:56
+msgid ""
+"You have selected multiple images and chosen PDF as the format.\\n\\nDo you "
+"want to merge them into a single PDF document?\\n(Click 'No' to convert them "
+"to separate PDF files)"
 msgstr ""
-"Format no suportat. Els valors possibles són: png (per defecte), jpeg, tiff"
+
+#. convert-image-format.sh:57
+msgid "Save Merged PDF As"
+msgstr ""
+
+#. convert-image-format.sh:60
+msgid "Conversion Errors"
+msgstr ""
+
+#. convert-image-format.sh:61
+msgid "The following files were skipped (unsupported format):"
+msgstr ""
+
+#. convert-image-format.sh:62
+msgid "Missing dependency:"
+msgstr ""
 
 #. convert-image-format@el-amine-404.nemo_action.in->Name
 msgid "Convert image(s) to another format"

--- a/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/convert-image-format@el-amine-404.pot
+++ b/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/convert-image-format@el-amine-404.pot
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: convert-image-format@el-amine-404 0.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2025-02-17 16:47-0500\n"
+"POT-Creation-Date: 2026-01-31 12:13+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -22,70 +22,139 @@ msgstr ""
 msgid "Convert Image Format"
 msgstr ""
 
-#. convert-image-format.sh:8
+#. convert-image-format.sh:19
 msgid "Convert Image(s) Format"
 msgstr ""
 
-#. convert-image-format.sh:9
+#. convert-image-format.sh:20
 msgid "Choose the format to convert the image(s) to:"
 msgstr ""
 
-#. convert-image-format.sh:10
+#. convert-image-format.sh:21
 msgid "Select"
 msgstr ""
 
-#. convert-image-format.sh:11
+#. convert-image-format.sh:22
 msgid "Format"
 msgstr ""
 
-#. convert-image-format.sh:12
+#. convert-image-format.sh:23
 msgid "Description"
 msgstr ""
 
-#. convert-image-format.sh:14
-msgid "Converting Images"
+#. convert-image-format.sh:26
+msgid ""
+"You have selected multiple images and chosen GIF as the format.\\n\\nDo you "
+"want to merge them into a single animated GIF?"
 msgstr ""
 
-#. convert-image-format.sh:15
-msgid "Processing..."
-msgstr ""
-
-#. convert-image-format.sh:16
-msgid "is not an image file and will be skipped"
+#. convert-image-format.sh:27
+msgid "Save GIF As"
 msgstr ""
 
 #. convert-image-format.sh:30
-msgid "PDF to Image Conversion"
+msgid "Advanced VTracer Options"
 msgstr ""
 
 #. convert-image-format.sh:31
+msgid "Configure how the bitmap is traced into vectors"
+msgstr ""
+
+#. convert-image-format.sh:32
+msgid "Mode"
+msgstr ""
+
+#. convert-image-format.sh:33
+msgid "Color Mode"
+msgstr ""
+
+#. convert-image-format.sh:34
+msgid "Clustering"
+msgstr ""
+
+#. convert-image-format.sh:35
+msgid "Filter Speckle (Cleaner) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:36
+msgid "Color Precision (More accurate)"
+msgstr ""
+
+#. convert-image-format.sh:37
+msgid "Gradient Step (Less layers) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:38
+msgid "Curve fitting"
+msgstr ""
+
+#. convert-image-format.sh:39
+msgid "Corner Threshold (Smoother) [0-180]"
+msgstr ""
+
+#. convert-image-format.sh:40
+msgid "Segment Length (More coarse) [3.5-10]"
+msgstr ""
+
+#. convert-image-format.sh:41
+msgid "Splice Threshold (Less accurate) (0-180)"
+msgstr ""
+
+#. convert-image-format.sh:45
+msgid "Converting Images"
+msgstr ""
+
+#. convert-image-format.sh:46
+msgid "Processing..."
+msgstr ""
+
+#. convert-image-format.sh:49
+msgid "PDF to Image Conversion"
+msgstr ""
+
+#. convert-image-format.sh:50
 msgid ""
 "Enter the required details for conversion.\\n\\nNote: Leaving fields empty "
 "will apply default values."
 msgstr ""
 
-#. convert-image-format.sh:32
+#. convert-image-format.sh:51
 msgid "Format (default: png)"
 msgstr ""
 
-#. convert-image-format.sh:34
+#. convert-image-format.sh:53
 msgid "Resolution / DPI (default: 300)"
 msgstr ""
 
-#. convert-image-format.sh:35
+#. convert-image-format.sh:54
 msgid "First Page (default: 1)"
 msgstr ""
 
-#. convert-image-format.sh:36
+#. convert-image-format.sh:55
 msgid "Last Page (default: last page of document)"
 msgstr ""
 
-#. convert-image-format.sh:46
-msgid "is not a valid PDF file and will be skipped"
+#. convert-image-format.sh:56
+msgid ""
+"You have selected multiple images and chosen PDF as the format.\\n\\nDo you "
+"want to merge them into a single PDF document?\\n(Click 'No' to convert them "
+"to separate PDF files)"
 msgstr ""
 
-#. convert-image-format.sh:47
-msgid "Unsupported format. Possible values are: png(default), jpeg, tiff"
+#. convert-image-format.sh:57
+msgid "Save Merged PDF As"
+msgstr ""
+
+#. convert-image-format.sh:60
+msgid "Conversion Errors"
+msgstr ""
+
+#. convert-image-format.sh:61
+msgid "The following files were skipped (unsupported format):"
+msgstr ""
+
+#. convert-image-format.sh:62
+msgid "Missing dependency:"
 msgstr ""
 
 #. convert-image-format@el-amine-404.nemo_action.in->Name

--- a/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/cs.po
+++ b/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/cs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: convert-image-format@el-amine-404 0.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2025-02-17 16:47-0500\n"
+"POT-Creation-Date: 2026-01-31 12:13+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: CZmisaCZ <CZmisaCZ@email.cz>\n"
 "Language-Team: \n"
@@ -23,43 +23,97 @@ msgstr ""
 msgid "Convert Image Format"
 msgstr "Převést formát obrázku"
 
-#. convert-image-format.sh:8
+#. convert-image-format.sh:19
 msgid "Convert Image(s) Format"
 msgstr "Převést formát obrázku(ů)"
 
-#. convert-image-format.sh:9
+#. convert-image-format.sh:20
 msgid "Choose the format to convert the image(s) to:"
 msgstr "Vyberte formát, do kterého chcete obrázek převést:"
 
-#. convert-image-format.sh:10
+#. convert-image-format.sh:21
 msgid "Select"
 msgstr "Vyberte"
 
-#. convert-image-format.sh:11
+#. convert-image-format.sh:22
 msgid "Format"
 msgstr "Formát"
 
-#. convert-image-format.sh:12
+#. convert-image-format.sh:23
 msgid "Description"
 msgstr "Popis"
 
-#. convert-image-format.sh:14
+#. convert-image-format.sh:26
+msgid ""
+"You have selected multiple images and chosen GIF as the format.\\n\\nDo you "
+"want to merge them into a single animated GIF?"
+msgstr ""
+
+#. convert-image-format.sh:27
+msgid "Save GIF As"
+msgstr ""
+
+#. convert-image-format.sh:30
+msgid "Advanced VTracer Options"
+msgstr ""
+
+#. convert-image-format.sh:31
+msgid "Configure how the bitmap is traced into vectors"
+msgstr ""
+
+#. convert-image-format.sh:32
+msgid "Mode"
+msgstr ""
+
+#. convert-image-format.sh:33
+msgid "Color Mode"
+msgstr ""
+
+#. convert-image-format.sh:34
+msgid "Clustering"
+msgstr ""
+
+#. convert-image-format.sh:35
+msgid "Filter Speckle (Cleaner) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:36
+msgid "Color Precision (More accurate)"
+msgstr ""
+
+#. convert-image-format.sh:37
+msgid "Gradient Step (Less layers) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:38
+msgid "Curve fitting"
+msgstr ""
+
+#. convert-image-format.sh:39
+msgid "Corner Threshold (Smoother) [0-180]"
+msgstr ""
+
+#. convert-image-format.sh:40
+msgid "Segment Length (More coarse) [3.5-10]"
+msgstr ""
+
+#. convert-image-format.sh:41
+msgid "Splice Threshold (Less accurate) (0-180)"
+msgstr ""
+
+#. convert-image-format.sh:45
 msgid "Converting Images"
 msgstr "Převádím obrázky"
 
-#. convert-image-format.sh:15
+#. convert-image-format.sh:46
 msgid "Processing..."
 msgstr "Zpracovává se..."
 
-#. convert-image-format.sh:16
-msgid "is not an image file and will be skipped"
-msgstr "soubor není obrázek a bude přeskočen"
-
-#. convert-image-format.sh:30
+#. convert-image-format.sh:49
 msgid "PDF to Image Conversion"
 msgstr "Konverze PDF na obrázek"
 
-#. convert-image-format.sh:31
+#. convert-image-format.sh:50
 msgid ""
 "Enter the required details for conversion.\\n\\nNote: Leaving fields empty "
 "will apply default values."
@@ -67,29 +121,44 @@ msgstr ""
 "Zadejte požadované údaje pro převod.\\n\\nPoznámka: Ponecháte-li pole "
 "prázdná, použijí se výchozí hodnoty."
 
-#. convert-image-format.sh:32
+#. convert-image-format.sh:51
 msgid "Format (default: png)"
 msgstr "Formát (výchozí: png)"
 
-#. convert-image-format.sh:34
+#. convert-image-format.sh:53
 msgid "Resolution / DPI (default: 300)"
 msgstr "Rozlišení / DPI (výchozí: 300)"
 
-#. convert-image-format.sh:35
+#. convert-image-format.sh:54
 msgid "First Page (default: 1)"
 msgstr "První stránka (výchozí: 1)"
 
-#. convert-image-format.sh:36
+#. convert-image-format.sh:55
 msgid "Last Page (default: last page of document)"
 msgstr "Poslední stránka (výchozí: poslední stránka dokumentu)"
 
-#. convert-image-format.sh:46
-msgid "is not a valid PDF file and will be skipped"
-msgstr "není platný soubor PDF a bude přeskočen"
+#. convert-image-format.sh:56
+msgid ""
+"You have selected multiple images and chosen PDF as the format.\\n\\nDo you "
+"want to merge them into a single PDF document?\\n(Click 'No' to convert them "
+"to separate PDF files)"
+msgstr ""
 
-#. convert-image-format.sh:47
-msgid "Unsupported format. Possible values are: png(default), jpeg, tiff"
-msgstr "Nepodporovaný formát. Možné hodnoty jsou: png (výchozí), jpeg, tiff"
+#. convert-image-format.sh:57
+msgid "Save Merged PDF As"
+msgstr ""
+
+#. convert-image-format.sh:60
+msgid "Conversion Errors"
+msgstr ""
+
+#. convert-image-format.sh:61
+msgid "The following files were skipped (unsupported format):"
+msgstr ""
+
+#. convert-image-format.sh:62
+msgid "Missing dependency:"
+msgstr ""
 
 #. convert-image-format@el-amine-404.nemo_action.in->Name
 msgid "Convert image(s) to another format"

--- a/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/da.po
+++ b/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/da.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: convert-image-format@el-amine-404 0.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2025-02-17 16:47-0500\n"
+"POT-Creation-Date: 2026-01-31 12:13+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -23,43 +23,97 @@ msgstr ""
 msgid "Convert Image Format"
 msgstr "Konvertér billedformat"
 
-#. convert-image-format.sh:8
+#. convert-image-format.sh:19
 msgid "Convert Image(s) Format"
 msgstr "Konvertér billeders format"
 
-#. convert-image-format.sh:9
+#. convert-image-format.sh:20
 msgid "Choose the format to convert the image(s) to:"
 msgstr "Vælg formatet, som billederne skal konverteres til:"
 
-#. convert-image-format.sh:10
+#. convert-image-format.sh:21
 msgid "Select"
 msgstr "Vælg"
 
-#. convert-image-format.sh:11
+#. convert-image-format.sh:22
 msgid "Format"
 msgstr "Format"
 
-#. convert-image-format.sh:12
+#. convert-image-format.sh:23
 msgid "Description"
 msgstr "Beskrivelse"
 
-#. convert-image-format.sh:14
+#. convert-image-format.sh:26
+msgid ""
+"You have selected multiple images and chosen GIF as the format.\\n\\nDo you "
+"want to merge them into a single animated GIF?"
+msgstr ""
+
+#. convert-image-format.sh:27
+msgid "Save GIF As"
+msgstr ""
+
+#. convert-image-format.sh:30
+msgid "Advanced VTracer Options"
+msgstr ""
+
+#. convert-image-format.sh:31
+msgid "Configure how the bitmap is traced into vectors"
+msgstr ""
+
+#. convert-image-format.sh:32
+msgid "Mode"
+msgstr ""
+
+#. convert-image-format.sh:33
+msgid "Color Mode"
+msgstr ""
+
+#. convert-image-format.sh:34
+msgid "Clustering"
+msgstr ""
+
+#. convert-image-format.sh:35
+msgid "Filter Speckle (Cleaner) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:36
+msgid "Color Precision (More accurate)"
+msgstr ""
+
+#. convert-image-format.sh:37
+msgid "Gradient Step (Less layers) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:38
+msgid "Curve fitting"
+msgstr ""
+
+#. convert-image-format.sh:39
+msgid "Corner Threshold (Smoother) [0-180]"
+msgstr ""
+
+#. convert-image-format.sh:40
+msgid "Segment Length (More coarse) [3.5-10]"
+msgstr ""
+
+#. convert-image-format.sh:41
+msgid "Splice Threshold (Less accurate) (0-180)"
+msgstr ""
+
+#. convert-image-format.sh:45
 msgid "Converting Images"
 msgstr "Konverterer billeder"
 
-#. convert-image-format.sh:15
+#. convert-image-format.sh:46
 msgid "Processing..."
 msgstr "Behandler …"
 
-#. convert-image-format.sh:16
-msgid "is not an image file and will be skipped"
-msgstr "er ikke en billedfil og springes over"
-
-#. convert-image-format.sh:30
+#. convert-image-format.sh:49
 msgid "PDF to Image Conversion"
 msgstr "Konvertering af PDF til billede"
 
-#. convert-image-format.sh:31
+#. convert-image-format.sh:50
 msgid ""
 "Enter the required details for conversion.\\n\\nNote: Leaving fields empty "
 "will apply default values."
@@ -67,30 +121,44 @@ msgstr ""
 "Indtast de krævede detaljer til konverteringen.\\n\\nBemærk: I tilfælde af "
 "tomme felter bruges standardværdier."
 
-#. convert-image-format.sh:32
+#. convert-image-format.sh:51
 msgid "Format (default: png)"
 msgstr "Format (standard: png)"
 
-#. convert-image-format.sh:34
+#. convert-image-format.sh:53
 msgid "Resolution / DPI (default: 300)"
 msgstr "Opløsning / DPI (standard: 300)"
 
-#. convert-image-format.sh:35
+#. convert-image-format.sh:54
 msgid "First Page (default: 1)"
 msgstr "Første side (standard: 1)"
 
-#. convert-image-format.sh:36
+#. convert-image-format.sh:55
 msgid "Last Page (default: last page of document)"
 msgstr "Sidste side (standard: dokumentets sidste side)"
 
-#. convert-image-format.sh:46
-msgid "is not a valid PDF file and will be skipped"
-msgstr "er ikke en gyldig PDF-fil og springes over"
-
-#. convert-image-format.sh:47
-msgid "Unsupported format. Possible values are: png(default), jpeg, tiff"
+#. convert-image-format.sh:56
+msgid ""
+"You have selected multiple images and chosen PDF as the format.\\n\\nDo you "
+"want to merge them into a single PDF document?\\n(Click 'No' to convert them "
+"to separate PDF files)"
 msgstr ""
-"Formatet understøttes ikke. Gyldige værdier er png (standard), jpeg, tiff"
+
+#. convert-image-format.sh:57
+msgid "Save Merged PDF As"
+msgstr ""
+
+#. convert-image-format.sh:60
+msgid "Conversion Errors"
+msgstr ""
+
+#. convert-image-format.sh:61
+msgid "The following files were skipped (unsupported format):"
+msgstr ""
+
+#. convert-image-format.sh:62
+msgid "Missing dependency:"
+msgstr ""
 
 #. convert-image-format@el-amine-404.nemo_action.in->Name
 msgid "Convert image(s) to another format"

--- a/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/es.po
+++ b/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/es.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: convert-image-format@el-amine-404 0.0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2025-02-17 16:47-0500\n"
+"POT-Creation-Date: 2026-01-31 12:13+0100\n"
 "PO-Revision-Date: 2024-09-16 11:32-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -22,43 +22,97 @@ msgstr ""
 msgid "Convert Image Format"
 msgstr "Convertir formato de imagen"
 
-#. convert-image-format.sh:8
+#. convert-image-format.sh:19
 msgid "Convert Image(s) Format"
 msgstr "Convertir formato de imagen(es)"
 
-#. convert-image-format.sh:9
+#. convert-image-format.sh:20
 msgid "Choose the format to convert the image(s) to:"
 msgstr "Elija el formato al que desea convertir las imágenes:"
 
-#. convert-image-format.sh:10
+#. convert-image-format.sh:21
 msgid "Select"
 msgstr "Seleccionar"
 
-#. convert-image-format.sh:11
+#. convert-image-format.sh:22
 msgid "Format"
 msgstr "Formato"
 
-#. convert-image-format.sh:12
+#. convert-image-format.sh:23
 msgid "Description"
 msgstr "Descripción"
 
-#. convert-image-format.sh:14
+#. convert-image-format.sh:26
+msgid ""
+"You have selected multiple images and chosen GIF as the format.\\n\\nDo you "
+"want to merge them into a single animated GIF?"
+msgstr ""
+
+#. convert-image-format.sh:27
+msgid "Save GIF As"
+msgstr ""
+
+#. convert-image-format.sh:30
+msgid "Advanced VTracer Options"
+msgstr ""
+
+#. convert-image-format.sh:31
+msgid "Configure how the bitmap is traced into vectors"
+msgstr ""
+
+#. convert-image-format.sh:32
+msgid "Mode"
+msgstr ""
+
+#. convert-image-format.sh:33
+msgid "Color Mode"
+msgstr ""
+
+#. convert-image-format.sh:34
+msgid "Clustering"
+msgstr ""
+
+#. convert-image-format.sh:35
+msgid "Filter Speckle (Cleaner) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:36
+msgid "Color Precision (More accurate)"
+msgstr ""
+
+#. convert-image-format.sh:37
+msgid "Gradient Step (Less layers) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:38
+msgid "Curve fitting"
+msgstr ""
+
+#. convert-image-format.sh:39
+msgid "Corner Threshold (Smoother) [0-180]"
+msgstr ""
+
+#. convert-image-format.sh:40
+msgid "Segment Length (More coarse) [3.5-10]"
+msgstr ""
+
+#. convert-image-format.sh:41
+msgid "Splice Threshold (Less accurate) (0-180)"
+msgstr ""
+
+#. convert-image-format.sh:45
 msgid "Converting Images"
 msgstr "Convertir imágenes"
 
-#. convert-image-format.sh:15
+#. convert-image-format.sh:46
 msgid "Processing..."
 msgstr "Procesando..."
 
-#. convert-image-format.sh:16
-msgid "is not an image file and will be skipped"
-msgstr "no es un archivo de imagen y se omitirá"
-
-#. convert-image-format.sh:30
+#. convert-image-format.sh:49
 msgid "PDF to Image Conversion"
 msgstr "Conversión de PDF a imagen"
 
-#. convert-image-format.sh:31
+#. convert-image-format.sh:50
 msgid ""
 "Enter the required details for conversion.\\n\\nNote: Leaving fields empty "
 "will apply default values."
@@ -66,30 +120,44 @@ msgstr ""
 "Introduzca los datos necesarios para la conversión.\n"
 "\\ Nota: Si deja los campos vacíos, se aplicarán los valores predeterminados."
 
-#. convert-image-format.sh:32
+#. convert-image-format.sh:51
 msgid "Format (default: png)"
 msgstr "Formato (por defecto: png)"
 
-#. convert-image-format.sh:34
+#. convert-image-format.sh:53
 msgid "Resolution / DPI (default: 300)"
 msgstr "Resolución / DPI (por defecto: 300)"
 
-#. convert-image-format.sh:35
+#. convert-image-format.sh:54
 msgid "First Page (default: 1)"
 msgstr "Primera página (por defecto: 1)"
 
-#. convert-image-format.sh:36
+#. convert-image-format.sh:55
 msgid "Last Page (default: last page of document)"
 msgstr "Última página (por defecto: última página del documento)"
 
-#. convert-image-format.sh:46
-msgid "is not a valid PDF file and will be skipped"
-msgstr "no es un archivo PDF válido y se omitirá"
-
-#. convert-image-format.sh:47
-msgid "Unsupported format. Possible values are: png(default), jpeg, tiff"
+#. convert-image-format.sh:56
+msgid ""
+"You have selected multiple images and chosen PDF as the format.\\n\\nDo you "
+"want to merge them into a single PDF document?\\n(Click 'No' to convert them "
+"to separate PDF files)"
 msgstr ""
-"Formato no admitido. Los valores posibles son: png(por defecto), jpeg, tiff"
+
+#. convert-image-format.sh:57
+msgid "Save Merged PDF As"
+msgstr ""
+
+#. convert-image-format.sh:60
+msgid "Conversion Errors"
+msgstr ""
+
+#. convert-image-format.sh:61
+msgid "The following files were skipped (unsupported format):"
+msgstr ""
+
+#. convert-image-format.sh:62
+msgid "Missing dependency:"
+msgstr ""
 
 #. convert-image-format@el-amine-404.nemo_action.in->Name
 msgid "Convert image(s) to another format"

--- a/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/eu.po
+++ b/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/eu.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: convert-image-format@el-amine-404 0.0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2025-02-17 16:47-0500\n"
+"POT-Creation-Date: 2026-01-31 12:13+0100\n"
 "PO-Revision-Date: 2024-08-14 07:37+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -22,71 +22,139 @@ msgstr ""
 msgid "Convert Image Format"
 msgstr "Bihurtu irudi formatua"
 
-#. convert-image-format.sh:8
+#. convert-image-format.sh:19
 msgid "Convert Image(s) Format"
 msgstr "Bihurtu Irudien formatua"
 
-#. convert-image-format.sh:9
+#. convert-image-format.sh:20
 msgid "Choose the format to convert the image(s) to:"
 msgstr "Aukeratu irudia(k) bihurtzeko formatua:"
 
-#. convert-image-format.sh:10
+#. convert-image-format.sh:21
 msgid "Select"
 msgstr "Hautatu"
 
-#. convert-image-format.sh:11
+#. convert-image-format.sh:22
 msgid "Format"
 msgstr "Formatua"
 
-#. convert-image-format.sh:12
+#. convert-image-format.sh:23
 msgid "Description"
 msgstr "Deskribapena"
 
-#. convert-image-format.sh:14
-msgid "Converting Images"
-msgstr "Irudiak bihurtzen"
+#. convert-image-format.sh:26
+msgid ""
+"You have selected multiple images and chosen GIF as the format.\\n\\nDo you "
+"want to merge them into a single animated GIF?"
+msgstr ""
 
-#. convert-image-format.sh:15
-msgid "Processing..."
-msgstr "Prozesatzen..."
-
-#. convert-image-format.sh:16
-msgid "is not an image file and will be skipped"
-msgstr "ez da irudi fitxategi bat eta saltatu egingo da"
+#. convert-image-format.sh:27
+msgid "Save GIF As"
+msgstr ""
 
 #. convert-image-format.sh:30
-msgid "PDF to Image Conversion"
+msgid "Advanced VTracer Options"
 msgstr ""
 
 #. convert-image-format.sh:31
+msgid "Configure how the bitmap is traced into vectors"
+msgstr ""
+
+#. convert-image-format.sh:32
+msgid "Mode"
+msgstr ""
+
+#. convert-image-format.sh:33
+msgid "Color Mode"
+msgstr ""
+
+#. convert-image-format.sh:34
+msgid "Clustering"
+msgstr ""
+
+#. convert-image-format.sh:35
+msgid "Filter Speckle (Cleaner) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:36
+msgid "Color Precision (More accurate)"
+msgstr ""
+
+#. convert-image-format.sh:37
+msgid "Gradient Step (Less layers) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:38
+msgid "Curve fitting"
+msgstr ""
+
+#. convert-image-format.sh:39
+msgid "Corner Threshold (Smoother) [0-180]"
+msgstr ""
+
+#. convert-image-format.sh:40
+msgid "Segment Length (More coarse) [3.5-10]"
+msgstr ""
+
+#. convert-image-format.sh:41
+msgid "Splice Threshold (Less accurate) (0-180)"
+msgstr ""
+
+#. convert-image-format.sh:45
+msgid "Converting Images"
+msgstr "Irudiak bihurtzen"
+
+#. convert-image-format.sh:46
+msgid "Processing..."
+msgstr "Prozesatzen..."
+
+#. convert-image-format.sh:49
+msgid "PDF to Image Conversion"
+msgstr ""
+
+#. convert-image-format.sh:50
 msgid ""
 "Enter the required details for conversion.\\n\\nNote: Leaving fields empty "
 "will apply default values."
 msgstr ""
 
-#. convert-image-format.sh:32
+#. convert-image-format.sh:51
 msgid "Format (default: png)"
 msgstr ""
 
-#. convert-image-format.sh:34
+#. convert-image-format.sh:53
 msgid "Resolution / DPI (default: 300)"
 msgstr ""
 
-#. convert-image-format.sh:35
+#. convert-image-format.sh:54
 msgid "First Page (default: 1)"
 msgstr ""
 
-#. convert-image-format.sh:36
+#. convert-image-format.sh:55
 msgid "Last Page (default: last page of document)"
 msgstr ""
 
-#. convert-image-format.sh:46
-#, fuzzy
-msgid "is not a valid PDF file and will be skipped"
-msgstr "ez da irudi fitxategi bat eta saltatu egingo da"
+#. convert-image-format.sh:56
+msgid ""
+"You have selected multiple images and chosen PDF as the format.\\n\\nDo you "
+"want to merge them into a single PDF document?\\n(Click 'No' to convert them "
+"to separate PDF files)"
+msgstr ""
 
-#. convert-image-format.sh:47
-msgid "Unsupported format. Possible values are: png(default), jpeg, tiff"
+#. convert-image-format.sh:57
+msgid "Save Merged PDF As"
+msgstr ""
+
+#. convert-image-format.sh:60
+msgid "Conversion Errors"
+msgstr ""
+
+#. convert-image-format.sh:61
+msgid "The following files were skipped (unsupported format):"
+msgstr ""
+
+#. convert-image-format.sh:62
+msgid "Missing dependency:"
 msgstr ""
 
 #. convert-image-format@el-amine-404.nemo_action.in->Name

--- a/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/fi.po
+++ b/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/fi.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: convert-image-format@el-amine-404 0.0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2025-02-17 16:47-0500\n"
+"POT-Creation-Date: 2026-01-31 12:13+0100\n"
 "PO-Revision-Date: 2025-04-13 10:26+0300\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -23,43 +23,97 @@ msgstr ""
 msgid "Convert Image Format"
 msgstr "Kuvien muutotyökalu"
 
-#. convert-image-format.sh:8
+#. convert-image-format.sh:19
 msgid "Convert Image(s) Format"
 msgstr "Valokuvien muuntotyökalu"
 
-#. convert-image-format.sh:9
+#. convert-image-format.sh:20
 msgid "Choose the format to convert the image(s) to:"
 msgstr "Valitse kuvamuoto johon kuva muunnetaan:"
 
-#. convert-image-format.sh:10
+#. convert-image-format.sh:21
 msgid "Select"
 msgstr "Valitse"
 
-#. convert-image-format.sh:11
+#. convert-image-format.sh:22
 msgid "Format"
 msgstr "Muoto"
 
-#. convert-image-format.sh:12
+#. convert-image-format.sh:23
 msgid "Description"
 msgstr "Kuvaus"
 
-#. convert-image-format.sh:14
+#. convert-image-format.sh:26
+msgid ""
+"You have selected multiple images and chosen GIF as the format.\\n\\nDo you "
+"want to merge them into a single animated GIF?"
+msgstr ""
+
+#. convert-image-format.sh:27
+msgid "Save GIF As"
+msgstr ""
+
+#. convert-image-format.sh:30
+msgid "Advanced VTracer Options"
+msgstr ""
+
+#. convert-image-format.sh:31
+msgid "Configure how the bitmap is traced into vectors"
+msgstr ""
+
+#. convert-image-format.sh:32
+msgid "Mode"
+msgstr ""
+
+#. convert-image-format.sh:33
+msgid "Color Mode"
+msgstr ""
+
+#. convert-image-format.sh:34
+msgid "Clustering"
+msgstr ""
+
+#. convert-image-format.sh:35
+msgid "Filter Speckle (Cleaner) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:36
+msgid "Color Precision (More accurate)"
+msgstr ""
+
+#. convert-image-format.sh:37
+msgid "Gradient Step (Less layers) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:38
+msgid "Curve fitting"
+msgstr ""
+
+#. convert-image-format.sh:39
+msgid "Corner Threshold (Smoother) [0-180]"
+msgstr ""
+
+#. convert-image-format.sh:40
+msgid "Segment Length (More coarse) [3.5-10]"
+msgstr ""
+
+#. convert-image-format.sh:41
+msgid "Splice Threshold (Less accurate) (0-180)"
+msgstr ""
+
+#. convert-image-format.sh:45
 msgid "Converting Images"
 msgstr "Muunnetaan kuvia"
 
-#. convert-image-format.sh:15
+#. convert-image-format.sh:46
 msgid "Processing..."
 msgstr "Käsitellään..."
 
-#. convert-image-format.sh:16
-msgid "is not an image file and will be skipped"
-msgstr "ei ole kuvatiedosto ja se ohitetaan"
-
-#. convert-image-format.sh:30
+#. convert-image-format.sh:49
 msgid "PDF to Image Conversion"
 msgstr "PDF ➡ Valokuva"
 
-#. convert-image-format.sh:31
+#. convert-image-format.sh:50
 msgid ""
 "Enter the required details for conversion.\\n\\nNote: Leaving fields empty "
 "will apply default values."
@@ -67,29 +121,44 @@ msgstr ""
 "Anna tarvittavat tiedot muuntamista varten.\\n\\nHuomaa: Jos kentät jää "
 "tyhjiksi, käytetään oletusarvoja."
 
-#. convert-image-format.sh:32
+#. convert-image-format.sh:51
 msgid "Format (default: png)"
 msgstr "Muoto (oletus: png)"
 
-#. convert-image-format.sh:34
+#. convert-image-format.sh:53
 msgid "Resolution / DPI (default: 300)"
 msgstr "Resoluutio (oletus: 300dpi)"
 
-#. convert-image-format.sh:35
+#. convert-image-format.sh:54
 msgid "First Page (default: 1)"
 msgstr "Ensimmäinen sivu (oletus: 1)"
 
-#. convert-image-format.sh:36
+#. convert-image-format.sh:55
 msgid "Last Page (default: last page of document)"
 msgstr "Viimeinen sivu (oletus: asiakirjan viimeinen sivu)"
 
-#. convert-image-format.sh:46
-msgid "is not a valid PDF file and will be skipped"
-msgstr "ei ole kelvollinen pdf-tiedosto ja se ohitetaan"
+#. convert-image-format.sh:56
+msgid ""
+"You have selected multiple images and chosen PDF as the format.\\n\\nDo you "
+"want to merge them into a single PDF document?\\n(Click 'No' to convert them "
+"to separate PDF files)"
+msgstr ""
 
-#. convert-image-format.sh:47
-msgid "Unsupported format. Possible values are: png(default), jpeg, tiff"
-msgstr "Ei tuettu. Mahdollisia arvoja ovat: png (oletus), jpeg ja  tiff"
+#. convert-image-format.sh:57
+msgid "Save Merged PDF As"
+msgstr ""
+
+#. convert-image-format.sh:60
+msgid "Conversion Errors"
+msgstr ""
+
+#. convert-image-format.sh:61
+msgid "The following files were skipped (unsupported format):"
+msgstr ""
+
+#. convert-image-format.sh:62
+msgid "Missing dependency:"
+msgstr ""
 
 #. convert-image-format@el-amine-404.nemo_action.in->Name
 msgid "Convert image(s) to another format"

--- a/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/fr.po
+++ b/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: convert-image-format@el-amine-404 0.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2025-02-17 16:47-0500\n"
+"POT-Creation-Date: 2026-01-31 12:13+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
@@ -23,43 +23,97 @@ msgstr ""
 msgid "Convert Image Format"
 msgstr "Changer le format d'image"
 
-#. convert-image-format.sh:8
+#. convert-image-format.sh:19
 msgid "Convert Image(s) Format"
 msgstr "Changer le format d'image(s)"
 
-#. convert-image-format.sh:9
+#. convert-image-format.sh:20
 msgid "Choose the format to convert the image(s) to:"
 msgstr "Choisissez le format dans lequel vous souhaitez convertir les images :"
 
-#. convert-image-format.sh:10
+#. convert-image-format.sh:21
 msgid "Select"
 msgstr "Choisir"
 
-#. convert-image-format.sh:11
+#. convert-image-format.sh:22
 msgid "Format"
 msgstr "Format"
 
-#. convert-image-format.sh:12
+#. convert-image-format.sh:23
 msgid "Description"
 msgstr "Description"
 
-#. convert-image-format.sh:14
+#. convert-image-format.sh:26
+msgid ""
+"You have selected multiple images and chosen GIF as the format.\\n\\nDo you "
+"want to merge them into a single animated GIF?"
+msgstr ""
+
+#. convert-image-format.sh:27
+msgid "Save GIF As"
+msgstr ""
+
+#. convert-image-format.sh:30
+msgid "Advanced VTracer Options"
+msgstr ""
+
+#. convert-image-format.sh:31
+msgid "Configure how the bitmap is traced into vectors"
+msgstr ""
+
+#. convert-image-format.sh:32
+msgid "Mode"
+msgstr ""
+
+#. convert-image-format.sh:33
+msgid "Color Mode"
+msgstr ""
+
+#. convert-image-format.sh:34
+msgid "Clustering"
+msgstr ""
+
+#. convert-image-format.sh:35
+msgid "Filter Speckle (Cleaner) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:36
+msgid "Color Precision (More accurate)"
+msgstr ""
+
+#. convert-image-format.sh:37
+msgid "Gradient Step (Less layers) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:38
+msgid "Curve fitting"
+msgstr ""
+
+#. convert-image-format.sh:39
+msgid "Corner Threshold (Smoother) [0-180]"
+msgstr ""
+
+#. convert-image-format.sh:40
+msgid "Segment Length (More coarse) [3.5-10]"
+msgstr ""
+
+#. convert-image-format.sh:41
+msgid "Splice Threshold (Less accurate) (0-180)"
+msgstr ""
+
+#. convert-image-format.sh:45
 msgid "Converting Images"
 msgstr "Conversion des images"
 
-#. convert-image-format.sh:15
+#. convert-image-format.sh:46
 msgid "Processing..."
 msgstr "En cours..."
 
-#. convert-image-format.sh:16
-msgid "is not an image file and will be skipped"
-msgstr "n'est pas un fichier image et sera ignoré"
-
-#. convert-image-format.sh:30
+#. convert-image-format.sh:49
 msgid "PDF to Image Conversion"
 msgstr "Conversion de PDF en image"
 
-#. convert-image-format.sh:31
+#. convert-image-format.sh:50
 msgid ""
 "Enter the required details for conversion.\\n\\nNote: Leaving fields empty "
 "will apply default values."
@@ -67,31 +121,44 @@ msgstr ""
 "Saisissez les informations nécessaires à la conversion.\\n\\nRemarque : si "
 "vous laissez des champs vides, les valeurs par défaut s'appliqueront."
 
-#. convert-image-format.sh:32
+#. convert-image-format.sh:51
 msgid "Format (default: png)"
 msgstr "Format (par défaut: png)"
 
-#. convert-image-format.sh:34
+#. convert-image-format.sh:53
 msgid "Resolution / DPI (default: 300)"
 msgstr "Résolution / DPI (par défaut : 300)"
 
-#. convert-image-format.sh:35
+#. convert-image-format.sh:54
 msgid "First Page (default: 1)"
 msgstr "Première page (par défaut : 1)"
 
-#. convert-image-format.sh:36
+#. convert-image-format.sh:55
 msgid "Last Page (default: last page of document)"
 msgstr "Dernière page (par défaut : dernière page du document)"
 
-#. convert-image-format.sh:46
-msgid "is not a valid PDF file and will be skipped"
-msgstr "n'est pas un fichier PDF valide et sera ignoré"
-
-#. convert-image-format.sh:47
-msgid "Unsupported format. Possible values are: png(default), jpeg, tiff"
+#. convert-image-format.sh:56
+msgid ""
+"You have selected multiple images and chosen PDF as the format.\\n\\nDo you "
+"want to merge them into a single PDF document?\\n(Click 'No' to convert them "
+"to separate PDF files)"
 msgstr ""
-"Format non pris en charge. Les valeurs possibles sont : png(par défaut), "
-"jpeg, tiff"
+
+#. convert-image-format.sh:57
+msgid "Save Merged PDF As"
+msgstr ""
+
+#. convert-image-format.sh:60
+msgid "Conversion Errors"
+msgstr ""
+
+#. convert-image-format.sh:61
+msgid "The following files were skipped (unsupported format):"
+msgstr ""
+
+#. convert-image-format.sh:62
+msgid "Missing dependency:"
+msgstr ""
 
 #. convert-image-format@el-amine-404.nemo_action.in->Name
 msgid "Convert image(s) to another format"

--- a/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/hu.po
+++ b/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/hu.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: convert-image-format@el-amine-404 0.0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2025-02-17 16:47-0500\n"
+"POT-Creation-Date: 2026-01-31 12:13+0100\n"
 "PO-Revision-Date: 2025-08-23 21:16+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -23,43 +23,97 @@ msgstr ""
 msgid "Convert Image Format"
 msgstr "Képformátum átalakítása"
 
-#. convert-image-format.sh:8
+#. convert-image-format.sh:19
 msgid "Convert Image(s) Format"
 msgstr "Kép(ek) formátumának átalakítása"
 
-#. convert-image-format.sh:9
+#. convert-image-format.sh:20
 msgid "Choose the format to convert the image(s) to:"
 msgstr "Válassza ki melyik formátumba kívánja konvertálni a kép(ek)et:"
 
-#. convert-image-format.sh:10
+#. convert-image-format.sh:21
 msgid "Select"
 msgstr "Kiválasztás"
 
-#. convert-image-format.sh:11
+#. convert-image-format.sh:22
 msgid "Format"
 msgstr "Formátum"
 
-#. convert-image-format.sh:12
+#. convert-image-format.sh:23
 msgid "Description"
 msgstr "Leírás"
 
-#. convert-image-format.sh:14
+#. convert-image-format.sh:26
+msgid ""
+"You have selected multiple images and chosen GIF as the format.\\n\\nDo you "
+"want to merge them into a single animated GIF?"
+msgstr ""
+
+#. convert-image-format.sh:27
+msgid "Save GIF As"
+msgstr ""
+
+#. convert-image-format.sh:30
+msgid "Advanced VTracer Options"
+msgstr ""
+
+#. convert-image-format.sh:31
+msgid "Configure how the bitmap is traced into vectors"
+msgstr ""
+
+#. convert-image-format.sh:32
+msgid "Mode"
+msgstr ""
+
+#. convert-image-format.sh:33
+msgid "Color Mode"
+msgstr ""
+
+#. convert-image-format.sh:34
+msgid "Clustering"
+msgstr ""
+
+#. convert-image-format.sh:35
+msgid "Filter Speckle (Cleaner) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:36
+msgid "Color Precision (More accurate)"
+msgstr ""
+
+#. convert-image-format.sh:37
+msgid "Gradient Step (Less layers) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:38
+msgid "Curve fitting"
+msgstr ""
+
+#. convert-image-format.sh:39
+msgid "Corner Threshold (Smoother) [0-180]"
+msgstr ""
+
+#. convert-image-format.sh:40
+msgid "Segment Length (More coarse) [3.5-10]"
+msgstr ""
+
+#. convert-image-format.sh:41
+msgid "Splice Threshold (Less accurate) (0-180)"
+msgstr ""
+
+#. convert-image-format.sh:45
 msgid "Converting Images"
 msgstr "Képek Konvertálása"
 
-#. convert-image-format.sh:15
+#. convert-image-format.sh:46
 msgid "Processing..."
 msgstr "Feldolgozás..."
 
-#. convert-image-format.sh:16
-msgid "is not an image file and will be skipped"
-msgstr "nem képfájl, és kihagyásra kerül"
-
-#. convert-image-format.sh:30
+#. convert-image-format.sh:49
 msgid "PDF to Image Conversion"
 msgstr "PDF-ből képre konvertálás"
 
-#. convert-image-format.sh:31
+#. convert-image-format.sh:50
 msgid ""
 "Enter the required details for conversion.\\n\\nNote: Leaving fields empty "
 "will apply default values."
@@ -67,30 +121,44 @@ msgstr ""
 "Adja meg az átalakításhoz szükséges adatokat.\\n\\nMegjegyzés: A mezők "
 "üresen hagyása alapértelmezett értékeket fog alkalmazni."
 
-#. convert-image-format.sh:32
+#. convert-image-format.sh:51
 msgid "Format (default: png)"
 msgstr "Formátum (alapértelmezett: png)"
 
-#. convert-image-format.sh:34
+#. convert-image-format.sh:53
 msgid "Resolution / DPI (default: 300)"
 msgstr "Felbontás / DPI (alapértelmezett: 300)"
 
-#. convert-image-format.sh:35
+#. convert-image-format.sh:54
 msgid "First Page (default: 1)"
 msgstr "Első oldal (alapértelmezett: 1)"
 
-#. convert-image-format.sh:36
+#. convert-image-format.sh:55
 msgid "Last Page (default: last page of document)"
 msgstr "Utolsó oldal (alapértelmezett: a dokumentum utolsó oldala)"
 
-#. convert-image-format.sh:46
-msgid "is not a valid PDF file and will be skipped"
-msgstr "nem érvényes PDF fájl és kihagyásra kerül"
-
-#. convert-image-format.sh:47
-msgid "Unsupported format. Possible values are: png(default), jpeg, tiff"
+#. convert-image-format.sh:56
+msgid ""
+"You have selected multiple images and chosen PDF as the format.\\n\\nDo you "
+"want to merge them into a single PDF document?\\n(Click 'No' to convert them "
+"to separate PDF files)"
 msgstr ""
-"Nem támogatott formátum. Lehetséges értékek: png(alapértelmezett), jpeg, tiff"
+
+#. convert-image-format.sh:57
+msgid "Save Merged PDF As"
+msgstr ""
+
+#. convert-image-format.sh:60
+msgid "Conversion Errors"
+msgstr ""
+
+#. convert-image-format.sh:61
+msgid "The following files were skipped (unsupported format):"
+msgstr ""
+
+#. convert-image-format.sh:62
+msgid "Missing dependency:"
+msgstr ""
 
 #. convert-image-format@el-amine-404.nemo_action.in->Name
 msgid "Convert image(s) to another format"

--- a/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/it.po
+++ b/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/it.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: convert-image-format@el-amine-404 0.0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2025-02-17 16:47-0500\n"
+"POT-Creation-Date: 2026-01-31 12:13+0100\n"
 "PO-Revision-Date: 2025-01-03 16:35+0100\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -23,43 +23,97 @@ msgstr ""
 msgid "Convert Image Format"
 msgstr "Converti formato immagine"
 
-#. convert-image-format.sh:8
+#. convert-image-format.sh:19
 msgid "Convert Image(s) Format"
 msgstr "Converti formato immagine(i)"
 
-#. convert-image-format.sh:9
+#. convert-image-format.sh:20
 msgid "Choose the format to convert the image(s) to:"
 msgstr "Scegli il formato in cui convertire le immagini:"
 
-#. convert-image-format.sh:10
+#. convert-image-format.sh:21
 msgid "Select"
 msgstr "Seleziona"
 
-#. convert-image-format.sh:11
+#. convert-image-format.sh:22
 msgid "Format"
 msgstr "Formato"
 
-#. convert-image-format.sh:12
+#. convert-image-format.sh:23
 msgid "Description"
 msgstr "Descrizione"
 
-#. convert-image-format.sh:14
+#. convert-image-format.sh:26
+msgid ""
+"You have selected multiple images and chosen GIF as the format.\\n\\nDo you "
+"want to merge them into a single animated GIF?"
+msgstr ""
+
+#. convert-image-format.sh:27
+msgid "Save GIF As"
+msgstr ""
+
+#. convert-image-format.sh:30
+msgid "Advanced VTracer Options"
+msgstr ""
+
+#. convert-image-format.sh:31
+msgid "Configure how the bitmap is traced into vectors"
+msgstr ""
+
+#. convert-image-format.sh:32
+msgid "Mode"
+msgstr ""
+
+#. convert-image-format.sh:33
+msgid "Color Mode"
+msgstr ""
+
+#. convert-image-format.sh:34
+msgid "Clustering"
+msgstr ""
+
+#. convert-image-format.sh:35
+msgid "Filter Speckle (Cleaner) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:36
+msgid "Color Precision (More accurate)"
+msgstr ""
+
+#. convert-image-format.sh:37
+msgid "Gradient Step (Less layers) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:38
+msgid "Curve fitting"
+msgstr ""
+
+#. convert-image-format.sh:39
+msgid "Corner Threshold (Smoother) [0-180]"
+msgstr ""
+
+#. convert-image-format.sh:40
+msgid "Segment Length (More coarse) [3.5-10]"
+msgstr ""
+
+#. convert-image-format.sh:41
+msgid "Splice Threshold (Less accurate) (0-180)"
+msgstr ""
+
+#. convert-image-format.sh:45
 msgid "Converting Images"
 msgstr "Convertendo le immagini"
 
-#. convert-image-format.sh:15
+#. convert-image-format.sh:46
 msgid "Processing..."
 msgstr "Elaborazione..."
 
-#. convert-image-format.sh:16
-msgid "is not an image file and will be skipped"
-msgstr "non è un file immagine e verrà ignorato"
-
-#. convert-image-format.sh:30
+#. convert-image-format.sh:49
 msgid "PDF to Image Conversion"
 msgstr "Conversione da PDF a immagine"
 
-#. convert-image-format.sh:31
+#. convert-image-format.sh:50
 msgid ""
 "Enter the required details for conversion.\\n\\nNote: Leaving fields empty "
 "will apply default values."
@@ -67,30 +121,44 @@ msgstr ""
 "Inserisci i dettagli richiesti per la conversione.\\n\\nNota: se lasci i "
 "campi vuoti, verranno applicati i valori predefiniti."
 
-#. convert-image-format.sh:32
+#. convert-image-format.sh:51
 msgid "Format (default: png)"
 msgstr "Formato (default: png)"
 
-#. convert-image-format.sh:34
+#. convert-image-format.sh:53
 msgid "Resolution / DPI (default: 300)"
 msgstr "Risoluzione / DPI (default: 300)"
 
-#. convert-image-format.sh:35
+#. convert-image-format.sh:54
 msgid "First Page (default: 1)"
 msgstr "Prima Pagina (default: 1)"
 
-#. convert-image-format.sh:36
+#. convert-image-format.sh:55
 msgid "Last Page (default: last page of document)"
 msgstr "Ultima Pagina (default: ultima pagina del documento)"
 
-#. convert-image-format.sh:46
-msgid "is not a valid PDF file and will be skipped"
-msgstr "non è un file PDF e verrà ignorato"
-
-#. convert-image-format.sh:47
-msgid "Unsupported format. Possible values are: png(default), jpeg, tiff"
+#. convert-image-format.sh:56
+msgid ""
+"You have selected multiple images and chosen PDF as the format.\\n\\nDo you "
+"want to merge them into a single PDF document?\\n(Click 'No' to convert them "
+"to separate PDF files)"
 msgstr ""
-"Formato non supportato. I valori possibili sono: png (default), jpeg, tiff"
+
+#. convert-image-format.sh:57
+msgid "Save Merged PDF As"
+msgstr ""
+
+#. convert-image-format.sh:60
+msgid "Conversion Errors"
+msgstr ""
+
+#. convert-image-format.sh:61
+msgid "The following files were skipped (unsupported format):"
+msgstr ""
+
+#. convert-image-format.sh:62
+msgid "Missing dependency:"
+msgstr ""
 
 #. convert-image-format@el-amine-404.nemo_action.in->Name
 msgid "Convert image(s) to another format"

--- a/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/ja.po
+++ b/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/ja.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: convert-image-format@el-amine-404 0.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2025-11-15 22:32+0900\n"
+"POT-Creation-Date: 2026-01-31 12:13+0100\n"
 "PO-Revision-Date: 2025-11-15 22:55+0900\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -22,74 +22,142 @@ msgstr ""
 msgid "Convert Image Format"
 msgstr "画像形式を変換"
 
-#. convert-image-format.sh:8
+#. convert-image-format.sh:19
 msgid "Convert Image(s) Format"
 msgstr "画像形式を変換"
 
-#. convert-image-format.sh:9
+#. convert-image-format.sh:20
 msgid "Choose the format to convert the image(s) to:"
 msgstr "画像をどの形式に変換するか選択してください:"
 
-#. convert-image-format.sh:10
+#. convert-image-format.sh:21
 msgid "Select"
 msgstr "選択"
 
-#. convert-image-format.sh:11
+#. convert-image-format.sh:22
 msgid "Format"
 msgstr "形式"
 
-#. convert-image-format.sh:12
+#. convert-image-format.sh:23
 msgid "Description"
 msgstr "説明"
 
-#. convert-image-format.sh:14
+#. convert-image-format.sh:26
+msgid ""
+"You have selected multiple images and chosen GIF as the format.\\n\\nDo you "
+"want to merge them into a single animated GIF?"
+msgstr ""
+
+#. convert-image-format.sh:27
+msgid "Save GIF As"
+msgstr ""
+
+#. convert-image-format.sh:30
+msgid "Advanced VTracer Options"
+msgstr ""
+
+#. convert-image-format.sh:31
+msgid "Configure how the bitmap is traced into vectors"
+msgstr ""
+
+#. convert-image-format.sh:32
+msgid "Mode"
+msgstr ""
+
+#. convert-image-format.sh:33
+msgid "Color Mode"
+msgstr ""
+
+#. convert-image-format.sh:34
+msgid "Clustering"
+msgstr ""
+
+#. convert-image-format.sh:35
+msgid "Filter Speckle (Cleaner) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:36
+msgid "Color Precision (More accurate)"
+msgstr ""
+
+#. convert-image-format.sh:37
+msgid "Gradient Step (Less layers) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:38
+msgid "Curve fitting"
+msgstr ""
+
+#. convert-image-format.sh:39
+msgid "Corner Threshold (Smoother) [0-180]"
+msgstr ""
+
+#. convert-image-format.sh:40
+msgid "Segment Length (More coarse) [3.5-10]"
+msgstr ""
+
+#. convert-image-format.sh:41
+msgid "Splice Threshold (Less accurate) (0-180)"
+msgstr ""
+
+#. convert-image-format.sh:45
 msgid "Converting Images"
 msgstr "画像を変換しています"
 
-#. convert-image-format.sh:15
+#. convert-image-format.sh:46
 msgid "Processing..."
 msgstr "処理しています..."
 
-#. convert-image-format.sh:16
-msgid "is not an image file and will be skipped"
-msgstr "は画像ファイルではないため、スキップします"
-
-#. convert-image-format.sh:30
+#. convert-image-format.sh:49
 msgid "PDF to Image Conversion"
 msgstr "PDF から画像に変換"
 
-#. convert-image-format.sh:31
+#. convert-image-format.sh:50
 msgid ""
 "Enter the required details for conversion.\\n\\nNote: Leaving fields empty "
 "will apply default values."
 msgstr ""
-"変換に必要な情報を入力してください。\\n\\n注: 空欄のままにすると、既定値が"
-"適用されます。"
+"変換に必要な情報を入力してください。\\n\\n注: 空欄のままにすると、既定値が適"
+"用されます。"
 
-#. convert-image-format.sh:32
+#. convert-image-format.sh:51
 msgid "Format (default: png)"
 msgstr "形式 (既定: png)"
 
-#. convert-image-format.sh:34
+#. convert-image-format.sh:53
 msgid "Resolution / DPI (default: 300)"
 msgstr "解像度 / DPI (既定: 300)"
 
-#. convert-image-format.sh:35
+#. convert-image-format.sh:54
 msgid "First Page (default: 1)"
 msgstr "開始ページ (既定: 1)"
 
-#. convert-image-format.sh:36
+#. convert-image-format.sh:55
 msgid "Last Page (default: last page of document)"
 msgstr "終了ページ (既定: 文書の最終ページ)"
 
-#. convert-image-format.sh:46
-msgid "is not a valid PDF file and will be skipped"
-msgstr "は有効な PDF ファイルではないため、スキップします"
-
-#. convert-image-format.sh:47
-msgid "Unsupported format. Possible values are: png(default), jpeg, tiff"
+#. convert-image-format.sh:56
+msgid ""
+"You have selected multiple images and chosen PDF as the format.\\n\\nDo you "
+"want to merge them into a single PDF document?\\n(Click 'No' to convert them "
+"to separate PDF files)"
 msgstr ""
-"サポートされていない形式です。指定できる値は: png (既定), jpeg, tiff です"
+
+#. convert-image-format.sh:57
+msgid "Save Merged PDF As"
+msgstr ""
+
+#. convert-image-format.sh:60
+msgid "Conversion Errors"
+msgstr ""
+
+#. convert-image-format.sh:61
+msgid "The following files were skipped (unsupported format):"
+msgstr ""
+
+#. convert-image-format.sh:62
+msgid "Missing dependency:"
+msgstr ""
 
 #. convert-image-format@el-amine-404.nemo_action.in->Name
 msgid "Convert image(s) to another format"

--- a/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/nl.po
+++ b/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: convert-image-format@el-amine-404 0.0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2025-02-17 16:47-0500\n"
+"POT-Creation-Date: 2026-01-31 12:13+0100\n"
 "PO-Revision-Date: 2024-11-27 10:45+0100\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -21,43 +21,97 @@ msgstr ""
 msgid "Convert Image Format"
 msgstr "Afbeeldingsformaat converteren"
 
-#. convert-image-format.sh:8
+#. convert-image-format.sh:19
 msgid "Convert Image(s) Format"
 msgstr "Afbeeldingsformaat converteren"
 
-#. convert-image-format.sh:9
+#. convert-image-format.sh:20
 msgid "Choose the format to convert the image(s) to:"
 msgstr "Kies het formaat om de afbeelding(en) naar te converteren:"
 
-#. convert-image-format.sh:10
+#. convert-image-format.sh:21
 msgid "Select"
 msgstr "Selecteer"
 
-#. convert-image-format.sh:11
+#. convert-image-format.sh:22
 msgid "Format"
 msgstr "Formaat"
 
-#. convert-image-format.sh:12
+#. convert-image-format.sh:23
 msgid "Description"
 msgstr "Beschrijving"
 
-#. convert-image-format.sh:14
+#. convert-image-format.sh:26
+msgid ""
+"You have selected multiple images and chosen GIF as the format.\\n\\nDo you "
+"want to merge them into a single animated GIF?"
+msgstr ""
+
+#. convert-image-format.sh:27
+msgid "Save GIF As"
+msgstr ""
+
+#. convert-image-format.sh:30
+msgid "Advanced VTracer Options"
+msgstr ""
+
+#. convert-image-format.sh:31
+msgid "Configure how the bitmap is traced into vectors"
+msgstr ""
+
+#. convert-image-format.sh:32
+msgid "Mode"
+msgstr ""
+
+#. convert-image-format.sh:33
+msgid "Color Mode"
+msgstr ""
+
+#. convert-image-format.sh:34
+msgid "Clustering"
+msgstr ""
+
+#. convert-image-format.sh:35
+msgid "Filter Speckle (Cleaner) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:36
+msgid "Color Precision (More accurate)"
+msgstr ""
+
+#. convert-image-format.sh:37
+msgid "Gradient Step (Less layers) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:38
+msgid "Curve fitting"
+msgstr ""
+
+#. convert-image-format.sh:39
+msgid "Corner Threshold (Smoother) [0-180]"
+msgstr ""
+
+#. convert-image-format.sh:40
+msgid "Segment Length (More coarse) [3.5-10]"
+msgstr ""
+
+#. convert-image-format.sh:41
+msgid "Splice Threshold (Less accurate) (0-180)"
+msgstr ""
+
+#. convert-image-format.sh:45
 msgid "Converting Images"
 msgstr "Afbeeldingen converteren"
 
-#. convert-image-format.sh:15
+#. convert-image-format.sh:46
 msgid "Processing..."
 msgstr "Verwerken..."
 
-#. convert-image-format.sh:16
-msgid "is not an image file and will be skipped"
-msgstr "is geen afbeeldingsbestand en zal worden overgeslagen"
-
-#. convert-image-format.sh:30
+#. convert-image-format.sh:49
 msgid "PDF to Image Conversion"
 msgstr "PDF naar afbeelding converteren"
 
-#. convert-image-format.sh:31
+#. convert-image-format.sh:50
 msgid ""
 "Enter the required details for conversion.\\n\\nNote: Leaving fields empty "
 "will apply default values."
@@ -65,30 +119,44 @@ msgstr ""
 "Voer de benodigde gegevens in voor de conversie.\\n\\nOpmerking: Velden leeg "
 "laten zal standaardwaarden toepassen."
 
-#. convert-image-format.sh:32
+#. convert-image-format.sh:51
 msgid "Format (default: png)"
 msgstr "Formaat (standaard: png)"
 
-#. convert-image-format.sh:34
+#. convert-image-format.sh:53
 msgid "Resolution / DPI (default: 300)"
 msgstr "Resolutie / DPI (standaard: 300)"
 
-#. convert-image-format.sh:35
+#. convert-image-format.sh:54
 msgid "First Page (default: 1)"
 msgstr "Eerste pagina (standaard: 1)"
 
-#. convert-image-format.sh:36
+#. convert-image-format.sh:55
 msgid "Last Page (default: last page of document)"
 msgstr "Laatste pagina (standaard: laatste pagina van het document)"
 
-#. convert-image-format.sh:46
-msgid "is not a valid PDF file and will be skipped"
-msgstr "is geen geldig PDF-bestand en zal worden overgeslagen"
-
-#. convert-image-format.sh:47
-msgid "Unsupported format. Possible values are: png(default), jpeg, tiff"
+#. convert-image-format.sh:56
+msgid ""
+"You have selected multiple images and chosen PDF as the format.\\n\\nDo you "
+"want to merge them into a single PDF document?\\n(Click 'No' to convert them "
+"to separate PDF files)"
 msgstr ""
-"Niet ondersteund formaat. Mogelijke waarden zijn: png (standaard), jpeg, tiff"
+
+#. convert-image-format.sh:57
+msgid "Save Merged PDF As"
+msgstr ""
+
+#. convert-image-format.sh:60
+msgid "Conversion Errors"
+msgstr ""
+
+#. convert-image-format.sh:61
+msgid "The following files were skipped (unsupported format):"
+msgstr ""
+
+#. convert-image-format.sh:62
+msgid "Missing dependency:"
+msgstr ""
 
 #. convert-image-format@el-amine-404.nemo_action.in->Name
 msgid "Convert image(s) to another format"

--- a/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/pt.po
+++ b/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/pt.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: convert-image-format@el-amine-404 0.0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2025-02-17 16:47-0500\n"
+"POT-Creation-Date: 2026-01-31 12:13+0100\n"
 "PO-Revision-Date: 2025-01-15 18:33+0000\n"
 "Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>\n"
 "Language-Team: \n"
@@ -24,43 +24,97 @@ msgstr ""
 msgid "Convert Image Format"
 msgstr "Converter formato de imagem"
 
-#. convert-image-format.sh:8
+#. convert-image-format.sh:19
 msgid "Convert Image(s) Format"
 msgstr "Converter formato da(s) imagem(ns)"
 
-#. convert-image-format.sh:9
+#. convert-image-format.sh:20
 msgid "Choose the format to convert the image(s) to:"
 msgstr "Escolha o formato para o qual pretende converter a(s) imagem(ns):"
 
-#. convert-image-format.sh:10
+#. convert-image-format.sh:21
 msgid "Select"
 msgstr "Selecione"
 
-#. convert-image-format.sh:11
+#. convert-image-format.sh:22
 msgid "Format"
 msgstr "Formato"
 
-#. convert-image-format.sh:12
+#. convert-image-format.sh:23
 msgid "Description"
 msgstr "Descrição"
 
-#. convert-image-format.sh:14
+#. convert-image-format.sh:26
+msgid ""
+"You have selected multiple images and chosen GIF as the format.\\n\\nDo you "
+"want to merge them into a single animated GIF?"
+msgstr ""
+
+#. convert-image-format.sh:27
+msgid "Save GIF As"
+msgstr ""
+
+#. convert-image-format.sh:30
+msgid "Advanced VTracer Options"
+msgstr ""
+
+#. convert-image-format.sh:31
+msgid "Configure how the bitmap is traced into vectors"
+msgstr ""
+
+#. convert-image-format.sh:32
+msgid "Mode"
+msgstr ""
+
+#. convert-image-format.sh:33
+msgid "Color Mode"
+msgstr ""
+
+#. convert-image-format.sh:34
+msgid "Clustering"
+msgstr ""
+
+#. convert-image-format.sh:35
+msgid "Filter Speckle (Cleaner) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:36
+msgid "Color Precision (More accurate)"
+msgstr ""
+
+#. convert-image-format.sh:37
+msgid "Gradient Step (Less layers) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:38
+msgid "Curve fitting"
+msgstr ""
+
+#. convert-image-format.sh:39
+msgid "Corner Threshold (Smoother) [0-180]"
+msgstr ""
+
+#. convert-image-format.sh:40
+msgid "Segment Length (More coarse) [3.5-10]"
+msgstr ""
+
+#. convert-image-format.sh:41
+msgid "Splice Threshold (Less accurate) (0-180)"
+msgstr ""
+
+#. convert-image-format.sh:45
 msgid "Converting Images"
 msgstr "A converter imagens"
 
-#. convert-image-format.sh:15
+#. convert-image-format.sh:46
 msgid "Processing..."
 msgstr "A processar..."
 
-#. convert-image-format.sh:16
-msgid "is not an image file and will be skipped"
-msgstr "não é um ficheiro de imagem e será ignorado"
-
-#. convert-image-format.sh:30
+#. convert-image-format.sh:49
 msgid "PDF to Image Conversion"
 msgstr "Conversão de PDF para imagem"
 
-#. convert-image-format.sh:31
+#. convert-image-format.sh:50
 msgid ""
 "Enter the required details for conversion.\\n\\nNote: Leaving fields empty "
 "will apply default values."
@@ -68,31 +122,44 @@ msgstr ""
 "Introduza os detalhes necessários para a conversão.\\n\\nNota: Se deixar os "
 "campos vazios, serão aplicados valores predefinidos."
 
-#. convert-image-format.sh:32
+#. convert-image-format.sh:51
 msgid "Format (default: png)"
 msgstr "Formato (predefinição: png)"
 
-#. convert-image-format.sh:34
+#. convert-image-format.sh:53
 msgid "Resolution / DPI (default: 300)"
 msgstr "Resolução / DPI (predefinição: 300)"
 
-#. convert-image-format.sh:35
+#. convert-image-format.sh:54
 msgid "First Page (default: 1)"
 msgstr "Primeira página (predefinição: 1)"
 
-#. convert-image-format.sh:36
+#. convert-image-format.sh:55
 msgid "Last Page (default: last page of document)"
 msgstr "Última página (predefinição: última página do documento)"
 
-#. convert-image-format.sh:46
-msgid "is not a valid PDF file and will be skipped"
-msgstr "não é um ficheiro PDF válido e será ignorado"
-
-#. convert-image-format.sh:47
-msgid "Unsupported format. Possible values are: png(default), jpeg, tiff"
+#. convert-image-format.sh:56
+msgid ""
+"You have selected multiple images and chosen PDF as the format.\\n\\nDo you "
+"want to merge them into a single PDF document?\\n(Click 'No' to convert them "
+"to separate PDF files)"
 msgstr ""
-"Formato não suportado. Os valores possíveis são: png (predefinição), jpeg, "
-"tiff"
+
+#. convert-image-format.sh:57
+msgid "Save Merged PDF As"
+msgstr ""
+
+#. convert-image-format.sh:60
+msgid "Conversion Errors"
+msgstr ""
+
+#. convert-image-format.sh:61
+msgid "The following files were skipped (unsupported format):"
+msgstr ""
+
+#. convert-image-format.sh:62
+msgid "Missing dependency:"
+msgstr ""
 
 #. convert-image-format@el-amine-404.nemo_action.in->Name
 msgid "Convert image(s) to another format"

--- a/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/uk.po
+++ b/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/uk.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: convert-image-format@el-amine-404 0.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2025-02-17 16:47-0500\n"
+"POT-Creation-Date: 2026-01-31 12:13+0100\n"
 "PO-Revision-Date: 2025-02-17 21:00\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -25,43 +25,97 @@ msgstr ""
 msgid "Convert Image Format"
 msgstr "Перетворити формат зображення"
 
-#. convert-image-format.sh:8
+#. convert-image-format.sh:19
 msgid "Convert Image(s) Format"
 msgstr "Перетворити формат зображень"
 
-#. convert-image-format.sh:9
+#. convert-image-format.sh:20
 msgid "Choose the format to convert the image(s) to:"
 msgstr "Виберіть формат для перетворення зображень:"
 
-#. convert-image-format.sh:10
+#. convert-image-format.sh:21
 msgid "Select"
 msgstr "Вибрати"
 
-#. convert-image-format.sh:11
+#. convert-image-format.sh:22
 msgid "Format"
 msgstr "Формат"
 
-#. convert-image-format.sh:12
+#. convert-image-format.sh:23
 msgid "Description"
 msgstr "Опис"
 
-#. convert-image-format.sh:14
+#. convert-image-format.sh:26
+msgid ""
+"You have selected multiple images and chosen GIF as the format.\\n\\nDo you "
+"want to merge them into a single animated GIF?"
+msgstr ""
+
+#. convert-image-format.sh:27
+msgid "Save GIF As"
+msgstr ""
+
+#. convert-image-format.sh:30
+msgid "Advanced VTracer Options"
+msgstr ""
+
+#. convert-image-format.sh:31
+msgid "Configure how the bitmap is traced into vectors"
+msgstr ""
+
+#. convert-image-format.sh:32
+msgid "Mode"
+msgstr ""
+
+#. convert-image-format.sh:33
+msgid "Color Mode"
+msgstr ""
+
+#. convert-image-format.sh:34
+msgid "Clustering"
+msgstr ""
+
+#. convert-image-format.sh:35
+msgid "Filter Speckle (Cleaner) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:36
+msgid "Color Precision (More accurate)"
+msgstr ""
+
+#. convert-image-format.sh:37
+msgid "Gradient Step (Less layers) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:38
+msgid "Curve fitting"
+msgstr ""
+
+#. convert-image-format.sh:39
+msgid "Corner Threshold (Smoother) [0-180]"
+msgstr ""
+
+#. convert-image-format.sh:40
+msgid "Segment Length (More coarse) [3.5-10]"
+msgstr ""
+
+#. convert-image-format.sh:41
+msgid "Splice Threshold (Less accurate) (0-180)"
+msgstr ""
+
+#. convert-image-format.sh:45
 msgid "Converting Images"
 msgstr "Конвертація зображень"
 
-#. convert-image-format.sh:15
+#. convert-image-format.sh:46
 msgid "Processing..."
 msgstr "Обробка..."
 
-#. convert-image-format.sh:16
-msgid "is not an image file and will be skipped"
-msgstr "не є файлом зображення і буде пропущений"
-
-#. convert-image-format.sh:30
+#. convert-image-format.sh:49
 msgid "PDF to Image Conversion"
 msgstr "Перетворення PDF в зображення"
 
-#. convert-image-format.sh:31
+#. convert-image-format.sh:50
 msgid ""
 "Enter the required details for conversion.\\n\\nNote: Leaving fields empty "
 "will apply default values."
@@ -69,30 +123,44 @@ msgstr ""
 "Введіть необхідні дані для перетворення.\\n\\nПримітка: До порожніх полів "
 "будуть застосовані значення за замовчуванням."
 
-#. convert-image-format.sh:32
+#. convert-image-format.sh:51
 msgid "Format (default: png)"
 msgstr "Format (за замовчуванням: png)"
 
-#. convert-image-format.sh:34
+#. convert-image-format.sh:53
 msgid "Resolution / DPI (default: 300)"
 msgstr "Роздільна здатність / DPI (за замовчуванням: 300)"
 
-#. convert-image-format.sh:35
+#. convert-image-format.sh:54
 msgid "First Page (default: 1)"
 msgstr "Перша сторінка (за замовчуванням: 1)"
 
-#. convert-image-format.sh:36
+#. convert-image-format.sh:55
 msgid "Last Page (default: last page of document)"
 msgstr "Остання сторінка (за замовчуванням: остання сторінка документа)"
 
-#. convert-image-format.sh:46
-msgid "is not a valid PDF file and will be skipped"
-msgstr "не є допустимим файлом PDF і буде пропущений"
-
-#. convert-image-format.sh:47
-msgid "Unsupported format. Possible values are: png(default), jpeg, tiff"
+#. convert-image-format.sh:56
+msgid ""
+"You have selected multiple images and chosen PDF as the format.\\n\\nDo you "
+"want to merge them into a single PDF document?\\n(Click 'No' to convert them "
+"to separate PDF files)"
 msgstr ""
-"Непідтримуваний формат. Можливі значення: png (за замовчуванням), jpeg, tiff"
+
+#. convert-image-format.sh:57
+msgid "Save Merged PDF As"
+msgstr ""
+
+#. convert-image-format.sh:60
+msgid "Conversion Errors"
+msgstr ""
+
+#. convert-image-format.sh:61
+msgid "The following files were skipped (unsupported format):"
+msgstr ""
+
+#. convert-image-format.sh:62
+msgid "Missing dependency:"
+msgstr ""
 
 #. convert-image-format@el-amine-404.nemo_action.in->Name
 msgid "Convert image(s) to another format"

--- a/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/vi.po
+++ b/convert-image-format@el-amine-404/files/convert-image-format@el-amine-404/po/vi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: convert-image-format@el-amine-404 0.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-actions/"
 "issues\n"
-"POT-Creation-Date: 2025-02-17 16:47-0500\n"
+"POT-Creation-Date: 2026-01-31 12:13+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: loccun <huynhloc.contact@gmail.com>\n"
 "Language-Team: \n"
@@ -23,43 +23,97 @@ msgstr ""
 msgid "Convert Image Format"
 msgstr "Chuyển đổi Định dạng Hình ảnh"
 
-#. convert-image-format.sh:8
+#. convert-image-format.sh:19
 msgid "Convert Image(s) Format"
 msgstr "Chuyển đổi Định dạng Hình ảnh"
 
-#. convert-image-format.sh:9
+#. convert-image-format.sh:20
 msgid "Choose the format to convert the image(s) to:"
 msgstr "Chọn định dạng để chuyển đổi hình ảnh:"
 
-#. convert-image-format.sh:10
+#. convert-image-format.sh:21
 msgid "Select"
 msgstr "Chọn"
 
-#. convert-image-format.sh:11
+#. convert-image-format.sh:22
 msgid "Format"
 msgstr "Định dạng"
 
-#. convert-image-format.sh:12
+#. convert-image-format.sh:23
 msgid "Description"
 msgstr "Mô tả"
 
-#. convert-image-format.sh:14
+#. convert-image-format.sh:26
+msgid ""
+"You have selected multiple images and chosen GIF as the format.\\n\\nDo you "
+"want to merge them into a single animated GIF?"
+msgstr ""
+
+#. convert-image-format.sh:27
+msgid "Save GIF As"
+msgstr ""
+
+#. convert-image-format.sh:30
+msgid "Advanced VTracer Options"
+msgstr ""
+
+#. convert-image-format.sh:31
+msgid "Configure how the bitmap is traced into vectors"
+msgstr ""
+
+#. convert-image-format.sh:32
+msgid "Mode"
+msgstr ""
+
+#. convert-image-format.sh:33
+msgid "Color Mode"
+msgstr ""
+
+#. convert-image-format.sh:34
+msgid "Clustering"
+msgstr ""
+
+#. convert-image-format.sh:35
+msgid "Filter Speckle (Cleaner) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:36
+msgid "Color Precision (More accurate)"
+msgstr ""
+
+#. convert-image-format.sh:37
+msgid "Gradient Step (Less layers) [0-128]"
+msgstr ""
+
+#. convert-image-format.sh:38
+msgid "Curve fitting"
+msgstr ""
+
+#. convert-image-format.sh:39
+msgid "Corner Threshold (Smoother) [0-180]"
+msgstr ""
+
+#. convert-image-format.sh:40
+msgid "Segment Length (More coarse) [3.5-10]"
+msgstr ""
+
+#. convert-image-format.sh:41
+msgid "Splice Threshold (Less accurate) (0-180)"
+msgstr ""
+
+#. convert-image-format.sh:45
 msgid "Converting Images"
 msgstr "Đang chuyển đổi hình ảnh"
 
-#. convert-image-format.sh:15
+#. convert-image-format.sh:46
 msgid "Processing..."
 msgstr "Đang xử lý..."
 
-#. convert-image-format.sh:16
-msgid "is not an image file and will be skipped"
-msgstr "không phải là tập tin hình ảnh và sẽ bị bỏ qua"
-
-#. convert-image-format.sh:30
+#. convert-image-format.sh:49
 msgid "PDF to Image Conversion"
 msgstr "Chuyển đổi PDF sang Hình ảnh"
 
-#. convert-image-format.sh:31
+#. convert-image-format.sh:50
 msgid ""
 "Enter the required details for conversion.\\n\\nNote: Leaving fields empty "
 "will apply default values."
@@ -67,29 +121,44 @@ msgstr ""
 "Nhập thông tin cần thiết để chuyển đổi.\\n\\nLưu ý: Để trống các trường sẽ "
 "áp dụng giá trị mặc định."
 
-#. convert-image-format.sh:32
+#. convert-image-format.sh:51
 msgid "Format (default: png)"
 msgstr "Định dạng (mặc định: png)"
 
-#. convert-image-format.sh:34
+#. convert-image-format.sh:53
 msgid "Resolution / DPI (default: 300)"
 msgstr "Độ phân giải / DPI (mặc định: 300)"
 
-#. convert-image-format.sh:35
+#. convert-image-format.sh:54
 msgid "First Page (default: 1)"
 msgstr "Trang đầu (mặc định: 1)"
 
-#. convert-image-format.sh:36
+#. convert-image-format.sh:55
 msgid "Last Page (default: last page of document)"
 msgstr "Trang cuối (mặc định: trang cuối của tài liệu)"
 
-#. convert-image-format.sh:46
-msgid "is not a valid PDF file and will be skipped"
-msgstr "không phải là tập tin PDF hợp lệ và sẽ bị bỏ qua"
+#. convert-image-format.sh:56
+msgid ""
+"You have selected multiple images and chosen PDF as the format.\\n\\nDo you "
+"want to merge them into a single PDF document?\\n(Click 'No' to convert them "
+"to separate PDF files)"
+msgstr ""
 
-#. convert-image-format.sh:47
-msgid "Unsupported format. Possible values are: png(default), jpeg, tiff"
-msgstr "Định dạng không được hỗ trợ. Các giá trị có thể là: png(mặc định), jpeg, tiff"
+#. convert-image-format.sh:57
+msgid "Save Merged PDF As"
+msgstr ""
+
+#. convert-image-format.sh:60
+msgid "Conversion Errors"
+msgstr ""
+
+#. convert-image-format.sh:61
+msgid "The following files were skipped (unsupported format):"
+msgstr ""
+
+#. convert-image-format.sh:62
+msgid "Missing dependency:"
+msgstr ""
 
 #. convert-image-format@el-amine-404.nemo_action.in->Name
 msgid "Convert image(s) to another format"


### PR DESCRIPTION
Hello

This PR updates the Convert Image Format action to version 0.2.0

- [x] validate and test the action
```bash
./test-spice convert-image-format@el-amine-404
```

- [x] update the translation template (.pot) files
```bash
./cinnamon-spices-makepot convert-image-format@el-amine-404
```

new features: 
- Add support for JPEG XL (*.jxl), fulfilling a request made by https://github.com/danielp96 on the website.
<img width="378" height="230" alt="image" src="https://github.com/user-attachments/assets/5dc23f89-277a-4338-af90-95472ce41a27" />

- When a user selects multiple images and chooses PDF as the target format, they are now presented with an option: convert them 1-to-1 (separate files) or merge all selected images into a single PDF document
<img width="336" height="101" alt="image" src="https://github.com/user-attachments/assets/42195941-c16b-4d07-af54-b7e0be17836c" />

- Similarly, if multiple images are selected and the target is GIF, the user can now choose to create a single animated GIF or convert the images individually
<img width="331" height="94" alt="image" src="https://github.com/user-attachments/assets/5d7b659b-da0a-4f1f-a790-025d65f9e7ff" />

- If a conversion fails, the user is now informed via a detailed popup window. This allows them to understand why the conversion failed (e.g., corrupt file) or share the log with the community for help
<img width="293" height="207" alt="image" src="https://github.com/user-attachments/assets/a1d2e7cf-bfcf-4f17-a00f-1f729cd65c58" />

- If an essential tool is missing, an error window will appear instructing the user on what is needed. (list of all required tools is in the README.md)
<img width="184" height="88" alt="image" src="https://github.com/user-attachments/assets/08589721-0cb2-40b1-8bb7-616a7e74cc04" />

Lastly, thank you for your review,  and I really appreciate the work you guys are doing 👍