### PR TITLE
Fix for the progress bars in the translate table

### DIFF
--- a/.translation-tables/translation-tables.py
+++ b/.translation-tables/translation-tables.py
@@ -92,7 +92,7 @@ def str2html_href(link, text):
 
 def value2html_progress_image(percentage):
     """ Creates a HTML code snippet, which links to a progress bar image to a given percentage. """
-    return '<img src="https://progress-bar.dev/' + percentage + '" alt="' + percentage + '%" />'
+    return '<img src="https://progressbar.info/' + percentage + '" alt="' + percentage + '%" />'
 
 def progress(untranslated, translated):
     """ Calculates percentage for translation progress. """


### PR DESCRIPTION
The website progress-bar.dev is not online =( 
So I replaced that to use progressbar.info, it works exactly the same way the other one used to work

Since I dont have a way to verify the previous layout I have just create a standard one 

with label
![Progress Bar](https://progressbar.info/label/56)

without label
![Progress Bar](https://progressbar.info/56)

we can also use this in the other spices pages