### PR TITLE
Update copy-path-to-clipboard@claudiux.nemo_action.in

### DIFF
--- a/copy-path-to-clipboard@claudiux/copy-path-to-clipboard@claudiux.nemo_action.in
+++ b/copy-path-to-clipboard@claudiux/copy-path-to-clipboard@claudiux.nemo_action.in
@@ -1,7 +1,9 @@
 [Nemo Action]
 _Name=Copy path to clipboard
 _Comment=Copy the full path of the selected item to the clipboard
-Exec=/usr/bin/env sh -c "echo -n %F | xclip -selection clipboard"
+# Exec=/usr/bin/env sh -c "echo -n %F | xclip -selection clipboard"
+# it is more useful %U (see /usr/share/nemo/action-nemo.md)
+Exec=/usr/bin/env sh -c "echo -n %U | xclip -selection clipboard"
 Selection=s
 Extensions=any;
 Icon-Name=edit-copy


### PR DESCRIPTION
I fixed "%n" with "%U" (see action-info.md in /usr/share/nemo), "%n" copies at run-time, if it's a file on the network it doesn't help (result example: /run/user/1000/gvfs/smb-share:...), while "%U" returns the URI, much more useful (result example on the same file: smb://'server'/'file_name')